### PR TITLE
ci: decrease renovate frequency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "schedule": ["every 3 months on the first day of the month"]
 }


### PR DESCRIPTION
Decreases Renovate frequency. It's only used for tooling in this repo.

Will stop PRs like this: https://github.com/googleapis/google-cloudevents-go/pull/28