### PR TITLE
feat: use int64 type instead of string for ints

### DIFF
--- a/cloud/audit/v1/log_entry_data.go
+++ b/cloud/audit/v1/log_entry_data.go
@@ -44,7 +44,7 @@ type ProtoPayload struct {
 	AuthorizationInfo     []AuthorizationInfo    `json:"authorizationInfo,omitempty"`    // Authorization information. If there are multiple; resources or permissions involved, then there is; one AuthorizationInfo element for each {resource, permission} tuple.
 	Metadata              *Metadata              `json:"metadata,omitempty"`             // Other service-specific data about the request, response, and other; information associated with the current audited event.
 	MethodName            *string                `json:"methodName,omitempty"`           // The name of the service method or operation.; For API calls, this should be the name of the API method.; For example,; ; "google.datastore.v1.Datastore.RunQuery"; "google.logging.v1.LoggingService.DeleteLog"
-	NumResponseItems      *string                `json:"numResponseItems,omitempty"`     // The number of items returned from a List or Query API method,; if applicable.
+	NumResponseItems      *int64                 `json:"numResponseItems,omitempty"`     // The number of items returned from a List or Query API method,; if applicable.
 	Request               *Request               `json:"request,omitempty"`              // The operation request. This may not include all request parameters,; such as those that are too large, privacy-sensitive, or duplicated; elsewhere in the log record.; It should never include user-generated data, such as file contents.; When the JSON object represented here has a proto equivalent, the proto; name will be indicated in the `@type` property.
 	RequestMetadata       *RequestMetadata       `json:"requestMetadata,omitempty"`      // Metadata about the operation.
 	ResourceLocation      *ResourceLocation      `json:"resourceLocation,omitempty"`     // The resource location information.
@@ -155,7 +155,7 @@ type RequestMetadata struct {
 type DestinationAttributes struct {
 	IP         *string           `json:"ip,omitempty"`        // The IP address of the peer.
 	Labels     map[string]string `json:"labels,omitempty"`    // The labels associated with the peer.
-	Port       *string           `json:"port,omitempty"`      // The network port of the peer.
+	Port       *int64            `json:"port,omitempty"`      // The network port of the peer.
 	Principal  *string           `json:"principal,omitempty"` // The identity of this peer. Similar to `Request.auth.principal`, but; relative to the peer instead of the request. For example, the; idenity associated with a load balancer that forwared the request.
 	RegionCode *string           `json:"regionCode,omitempty"`// The CLDR country/region code associated with the above IP address.; If the IP address is private, the `region_code` should reflect the; physical location where this peer is running.
 }
@@ -179,7 +179,7 @@ type RequestAttributes struct {
 	Query    *string           `json:"query,omitempty"`   // The HTTP URL query in the format of `name1=value1&name2=value2`, as it; appears in the first line of the HTTP request. No decoding is performed.
 	Reason   *string           `json:"reason,omitempty"`  // A special parameter for request reason. It is used by security systems; to associate auditing information with a request.
 	Scheme   *string           `json:"scheme,omitempty"`  // The HTTP URL scheme, such as `http` and `https`.
-	Size     *string           `json:"size,omitempty"`    // The HTTP request size in bytes. If unknown, it must be -1.
+	Size     *int64            `json:"size,omitempty"`    // The HTTP request size in bytes. If unknown, it must be -1.
 	Time     *string           `json:"time,omitempty"`    // The timestamp when the `destination` service receives the first byte of; the request.
 }
 

--- a/cloud/cloudbuild/v1/build_event_data.go
+++ b/cloud/cloudbuild/v1/build_event_data.go
@@ -76,7 +76,7 @@ type ObjectsTiming struct {
 
 // Special options for this build.
 type Options struct {
-	DiskSizeGB            *string                       `json:"diskSizeGb,omitempty"`          // Requested disk size for the VM that runs the build. Note that this is *NOT*; "disk free"; some of the space will be used by the operating system and; build utilities. Also note that this is the minimum disk size that will be; allocated for the build -- the build may run with a larger disk than; requested. At present, the maximum disk size is 1000GB; builds that request; more than the maximum are rejected with an error.
+	DiskSizeGB            *int64                        `json:"diskSizeGb,omitempty"`          // Requested disk size for the VM that runs the build. Note that this is *NOT*; "disk free"; some of the space will be used by the operating system and; build utilities. Also note that this is the minimum disk size that will be; allocated for the build -- the build may run with a larger disk than; requested. At present, the maximum disk size is 1000GB; builds that request; more than the maximum are rejected with an error.
 	Env                   []string                      `json:"env,omitempty"`                 // A list of global environment variable definitions that will exist for all; build steps in this build. If a variable is defined in both globally and in; a build step, the variable will use the build step value.; ; The elements are of the form "KEY=VALUE" for the environment variable "KEY"; being given the value "VALUE".
 	Logging               *Logging                      `json:"logging"`                       // Option to specify the logging mode, which determines where the logs are; stored.
 	LogStreamingOption    *LogStreamingOption           `json:"logStreamingOption"`            // Option to define build log streaming behavior to Google Cloud; Storage.
@@ -102,8 +102,8 @@ type Volume struct {
 //
 // The TTL starts ticking from create_time.
 type QueueTTL struct {
-	Nanos   *int64  `json:"nanos,omitempty"`  // Signed fractions of a second at nanosecond resolution of the span; of time. Durations less than one second are represented with a 0; `seconds` field and a positive or negative `nanos` field. For durations; of one second or more, a non-zero value for the `nanos` field must be; of the same sign as the `seconds` field. Must be from -999,999,999; to +999,999,999 inclusive.
-	Seconds *string `json:"seconds,omitempty"`// Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+	Nanos   *int64 `json:"nanos,omitempty"`  // Signed fractions of a second at nanosecond resolution of the span; of time. Durations less than one second are represented with a 0; `seconds` field and a positive or negative `nanos` field. For durations; of one second or more, a non-zero value for the `nanos` field must be; of the same sign as the `seconds` field. Must be from -999,999,999; to +999,999,999 inclusive.
+	Seconds *int64 `json:"seconds,omitempty"`// Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
 }
 
 // Results of the build.
@@ -113,7 +113,7 @@ type Results struct {
 	BuildStepImages  []string        `json:"buildStepImages,omitempty"` // List of build step digests, in the order corresponding to build step; indices.
 	BuildStepOutputs []string        `json:"buildStepOutputs,omitempty"`// List of build step outputs, produced by builder images, in the order; corresponding to build step indices.; ; [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders); can produce this output by writing to `$BUILDER_OUTPUT/output`.; Only the first 4KB of data is stored.
 	Images           []Image         `json:"images,omitempty"`          // Container images that were built as a part of the build.
-	NumArtifacts     *string         `json:"numArtifacts,omitempty"`    // Number of artifacts uploaded. Only populated when artifacts are uploaded.
+	NumArtifacts     *int64          `json:"numArtifacts,omitempty"`    // Number of artifacts uploaded. Only populated when artifacts are uploaded.
 }
 
 // Time to push all non-container artifacts.
@@ -176,7 +176,7 @@ type RepoSourceClass struct {
 // Location of the source in an archive file in Google Cloud Storage.
 type StorageSourceClass struct {
 	Bucket     *string `json:"bucket,omitempty"`    // Google Cloud Storage bucket containing the source (see; [Bucket Name; Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
-	Generation *string `json:"generation,omitempty"`// Google Cloud Storage generation for the object. If the generation is; omitted, the latest generation will be used.
+	Generation *int64  `json:"generation,omitempty"`// Google Cloud Storage generation for the object. If the generation is; omitted, the latest generation will be used.
 	Object     *string `json:"object,omitempty"`    // Google Cloud Storage object containing the source.
 }
 
@@ -223,7 +223,7 @@ type ResolvedRepoSourceClass struct {
 // Location of the source in an archive file in Google Cloud Storage.
 type ResolvedStorageSourceClass struct {
 	Bucket     *string `json:"bucket,omitempty"`    // Google Cloud Storage bucket containing the source (see; [Bucket Name; Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
-	Generation *string `json:"generation,omitempty"`// Google Cloud Storage generation for the object. If the generation is; omitted, the latest generation will be used.
+	Generation *int64  `json:"generation,omitempty"`// Google Cloud Storage generation for the object. If the generation is; omitted, the latest generation will be used.
 	Object     *string `json:"object,omitempty"`    // Google Cloud Storage object containing the source.
 }
 
@@ -259,8 +259,8 @@ type PullTiming struct {
 // time limit and will be allowed to continue to run until either it completes
 // or the build itself times out.
 type StepTimeout struct {
-	Nanos   *int64  `json:"nanos,omitempty"`  // Signed fractions of a second at nanosecond resolution of the span; of time. Durations less than one second are represented with a 0; `seconds` field and a positive or negative `nanos` field. For durations; of one second or more, a non-zero value for the `nanos` field must be; of the same sign as the `seconds` field. Must be from -999,999,999; to +999,999,999 inclusive.
-	Seconds *string `json:"seconds,omitempty"`// Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+	Nanos   *int64 `json:"nanos,omitempty"`  // Signed fractions of a second at nanosecond resolution of the span; of time. Durations less than one second are represented with a 0; `seconds` field and a positive or negative `nanos` field. For durations; of one second or more, a non-zero value for the `nanos` field must be; of the same sign as the `seconds` field. Must be from -999,999,999; to +999,999,999 inclusive.
+	Seconds *int64 `json:"seconds,omitempty"`// Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
 }
 
 // Stores timing information for executing this build step.
@@ -277,8 +277,8 @@ type StepTiming struct {
 // granularity. If this amount of time elapses, work on the build will cease
 // and the build status will be `TIMEOUT`.
 type BuildEventDataTimeout struct {
-	Nanos   *int64  `json:"nanos,omitempty"`  // Signed fractions of a second at nanosecond resolution of the span; of time. Durations less than one second are represented with a 0; `seconds` field and a positive or negative `nanos` field. For durations; of one second or more, a non-zero value for the `nanos` field must be; of the same sign as the `seconds` field. Must be from -999,999,999; to +999,999,999 inclusive.
-	Seconds *string `json:"seconds,omitempty"`// Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+	Nanos   *int64 `json:"nanos,omitempty"`  // Signed fractions of a second at nanosecond resolution of the span; of time. Durations less than one second are represented with a 0; `seconds` field and a positive or negative `nanos` field. For durations; of one second or more, a non-zero value for the `nanos` field must be; of the same sign as the `seconds` field. Must be from -999,999,999; to +999,999,999 inclusive.
+	Seconds *int64 `json:"seconds,omitempty"`// Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
 }
 
 // Stores timing information for pushing all artifact objects.

--- a/cloud/firestore/v1/document_event_data.go
+++ b/cloud/firestore/v1/document_event_data.go
@@ -40,7 +40,7 @@ type OldValueField struct {
 	BytesValue     *string        `json:"bytesValue,omitempty"`    // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
 	DoubleValue    *float64       `json:"doubleValue,omitempty"`   // A double value.
 	GeoPointValue  *GeoPointValue `json:"geoPointValue,omitempty"` // A geo point value representing a point on the surface of Earth.
-	IntegerValue   *string        `json:"integerValue,omitempty"`  // An integer value.
+	IntegerValue   *int64         `json:"integerValue,omitempty"`  // An integer value.
 	MapValue       *MapValue      `json:"mapValue,omitempty"`      // A map value.
 	NullValue      *NullValue     `json:"nullValue"`               // A null value.
 	ReferenceValue *string        `json:"referenceValue,omitempty"`// A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
@@ -55,7 +55,7 @@ type MapValueField struct {
 	BytesValue     *string        `json:"bytesValue,omitempty"`    // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
 	DoubleValue    *float64       `json:"doubleValue,omitempty"`   // A double value.
 	GeoPointValue  *GeoPointValue `json:"geoPointValue,omitempty"` // A geo point value representing a point on the surface of Earth.
-	IntegerValue   *string        `json:"integerValue,omitempty"`  // An integer value.
+	IntegerValue   *int64         `json:"integerValue,omitempty"`  // An integer value.
 	MapValue       *MapValue      `json:"mapValue,omitempty"`      // A map value.
 	NullValue      *NullValue     `json:"nullValue"`               // A null value.
 	ReferenceValue *string        `json:"referenceValue,omitempty"`// A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
@@ -75,7 +75,7 @@ type ValueElement struct {
 	BytesValue     *string        `json:"bytesValue,omitempty"`    // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
 	DoubleValue    *float64       `json:"doubleValue,omitempty"`   // A double value.
 	GeoPointValue  *GeoPointValue `json:"geoPointValue,omitempty"` // A geo point value representing a point on the surface of Earth.
-	IntegerValue   *string        `json:"integerValue,omitempty"`  // An integer value.
+	IntegerValue   *int64         `json:"integerValue,omitempty"`  // An integer value.
 	MapValue       *MapValue      `json:"mapValue,omitempty"`      // A map value.
 	NullValue      *NullValue     `json:"nullValue"`               // A null value.
 	ReferenceValue *string        `json:"referenceValue,omitempty"`// A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.

--- a/cloud/storage/v1/storage_object_data.go
+++ b/cloud/storage/v1/storage_object_data.go
@@ -28,18 +28,18 @@ type StorageObjectData struct {
 	CustomerEncryption      *CustomerEncryption `json:"customerEncryption,omitempty"`     // Metadata of customer-supplied encryption key, if the object is encrypted by; such a key.
 	Etag                    *string             `json:"etag,omitempty"`                   // HTTP 1.1 Entity tag for the object. See; [https://tools.ietf.org/html/rfc7232#section-2.3][RFC 7232 §2.3].
 	EventBasedHold          *bool               `json:"eventBasedHold,omitempty"`         // Whether an object is under event-based hold.
-	Generation              *string             `json:"generation,omitempty"`             // The content generation of this object. Used for object versioning.; Attempting to set this field will result in an error.
+	Generation              *int64              `json:"generation,omitempty"`             // The content generation of this object. Used for object versioning.; Attempting to set this field will result in an error.
 	ID                      *string             `json:"id,omitempty"`                     // The ID of the object, including the bucket name, object name, and; generation number.
 	Kind                    *string             `json:"kind,omitempty"`                   // The kind of item this is. For objects, this is always "storage#object".
 	KmsKeyName              *string             `json:"kmsKeyName,omitempty"`             // Cloud KMS Key used to encrypt this object, if the object is encrypted by; such a key.
 	Md5Hash                 *string             `json:"md5Hash,omitempty"`                // MD5 hash of the data; encoded using base64 as per; [https://tools.ietf.org/html/rfc4648#section-4][RFC 4648 §4]. For more; information about using the MD5 hash, see; [https://cloud.google.com/storage/docs/hashes-etags#_JSONAPI][Hashes and; ETags: Best Practices].
 	MediaLink               *string             `json:"mediaLink,omitempty"`              // Media download link.
 	Metadata                map[string]string   `json:"metadata,omitempty"`               // User-provided metadata, in key/value pairs.
-	Metageneration          *string             `json:"metageneration,omitempty"`         // The version of the metadata for this object at this generation. Used for; preconditions and for detecting changes in metadata. A metageneration; number is only meaningful in the context of a particular generation of a; particular object.
+	Metageneration          *int64              `json:"metageneration,omitempty"`         // The version of the metadata for this object at this generation. Used for; preconditions and for detecting changes in metadata. A metageneration; number is only meaningful in the context of a particular generation of a; particular object.
 	Name                    *string             `json:"name,omitempty"`                   // The name of the object.
 	RetentionExpirationTime *string             `json:"retentionExpirationTime,omitempty"`// A server-determined value that specifies the earliest time that the; object's retention period expires.
 	SelfLink                *string             `json:"selfLink,omitempty"`               // The link to this object.
-	Size                    *string             `json:"size,omitempty"`                   // Content-Length of the object data in bytes, matching; [https://tools.ietf.org/html/rfc7230#section-3.3.2][RFC 7230 §3.3.2].
+	Size                    *int64              `json:"size,omitempty"`                   // Content-Length of the object data in bytes, matching; [https://tools.ietf.org/html/rfc7230#section-3.3.2][RFC 7230 §3.3.2].
 	StorageClass            *string             `json:"storageClass,omitempty"`           // Storage class of the object.
 	TemporaryHold           *bool               `json:"temporaryHold,omitempty"`          // Whether an object is under temporary hold.
 	TimeCreated             *string             `json:"timeCreated,omitempty"`            // The creation time of the object.; Attempting to set this field will result in an error.

--- a/firebase/analytics/v1/analytics_log_data.go
+++ b/firebase/analytics/v1/analytics_log_data.go
@@ -26,8 +26,8 @@ type EventDim struct {
 	Date                    *string                   `json:"date,omitempty"`                   // The date on which this event was logged.; (YYYYMMDD format in the registered timezone of your app.)
 	Name                    *string                   `json:"name,omitempty"`                   // The name of this event.
 	Params                  map[string]AnalyticsValue `json:"params,omitempty"`                 // A repeated record of the parameters associated with this event.
-	PreviousTimestampMicros *string                   `json:"previousTimestampMicros,omitempty"`// UTC client time when the previous event happened.
-	TimestampMicros         *string                   `json:"timestampMicros,omitempty"`        // UTC client time when the event happened.
+	PreviousTimestampMicros *int64                    `json:"previousTimestampMicros,omitempty"`// UTC client time when the previous event happened.
+	TimestampMicros         *int64                    `json:"timestampMicros,omitempty"`        // UTC client time when the event happened.
 	ValueInUsd              *float64                  `json:"valueInUsd,omitempty"`             // Value param in USD.
 }
 
@@ -36,7 +36,7 @@ type EventDim struct {
 type AnalyticsValue struct {
 	DoubleValue *float64 `json:"doubleValue,omitempty"`
 	FloatValue  *float64 `json:"floatValue,omitempty"` 
-	IntValue    *string  `json:"intValue,omitempty"`   
+	IntValue    *int64   `json:"intValue,omitempty"`   
 	StringValue *string  `json:"stringValue,omitempty"`
 }
 
@@ -45,7 +45,7 @@ type UserDim struct {
 	AppInfo                  *AppInfo                `json:"appInfo,omitempty"`                 // App information.
 	BundleInfo               *BundleInfo             `json:"bundleInfo,omitempty"`              // Information regarding the bundle in which these events were uploaded.
 	DeviceInfo               *DeviceInfo             `json:"deviceInfo,omitempty"`              // Device information.
-	FirstOpenTimestampMicros *string                 `json:"firstOpenTimestampMicros,omitempty"`// The time (in microseconds) at which the user first opened the app.
+	FirstOpenTimestampMicros *int64                  `json:"firstOpenTimestampMicros,omitempty"`// The time (in microseconds) at which the user first opened the app.
 	GeoInfo                  *GeoInfo                `json:"geoInfo,omitempty"`                 // User's geographic information.
 	LtvInfo                  *LtvInfo                `json:"ltvInfo,omitempty"`                 // Lifetime Value information about this user.
 	TrafficSource            *TrafficSource          `json:"trafficSource,omitempty"`           // Information about marketing campaign which acquired the user.
@@ -64,8 +64,8 @@ type AppInfo struct {
 
 // Information regarding the bundle in which these events were uploaded.
 type BundleInfo struct {
-	BundleSequenceID            *int64  `json:"bundleSequenceId,omitempty"`           // Monotonically increasing index for each bundle set by SDK.
-	ServerTimestampOffsetMicros *string `json:"serverTimestampOffsetMicros,omitempty"`// Timestamp offset between collection time and upload time.
+	BundleSequenceID            *int64 `json:"bundleSequenceId,omitempty"`           // Monotonically increasing index for each bundle set by SDK.
+	ServerTimestampOffsetMicros *int64 `json:"serverTimestampOffsetMicros,omitempty"`// Timestamp offset between collection time and upload time.
 }
 
 // Device information.
@@ -105,9 +105,9 @@ type TrafficSource struct {
 }
 
 type UserProperty struct {
-	Index            *int64  `json:"index,omitempty"`           // Index for user property (one-based).
-	SetTimestampUsec *string `json:"setTimestampUsec,omitempty"`// UTC client time when user property was last set.
-	Value            *Value  `json:"value,omitempty"`           // Last set value of user property.
+	Index            *int64 `json:"index,omitempty"`           // Index for user property (one-based).
+	SetTimestampUsec *int64 `json:"setTimestampUsec,omitempty"`// UTC client time when user property was last set.
+	Value            *Value `json:"value,omitempty"`           // Last set value of user property.
 }
 
 // Last set value of user property.
@@ -117,7 +117,7 @@ type UserProperty struct {
 type Value struct {
 	DoubleValue *float64 `json:"doubleValue,omitempty"`
 	FloatValue  *float64 `json:"floatValue,omitempty"` 
-	IntValue    *string  `json:"intValue,omitempty"`   
+	IntValue    *int64   `json:"intValue,omitempty"`   
 	StringValue *string  `json:"stringValue,omitempty"`
 }
 

--- a/firebase/remoteconfig/v1/remote_config_event_data.go
+++ b/firebase/remoteconfig/v1/remote_config_event_data.go
@@ -18,12 +18,12 @@ import "encoding/json"
 // The data within all Firebase Remote Config events.
 type RemoteConfigEventData struct {
 	Description    *string     `json:"description,omitempty"`   // The user-provided description of the corresponding Remote Config template.
-	RollbackSource *string     `json:"rollbackSource,omitempty"`// Only present if this version is the result of a rollback, and will be the; version number of the Remote Config template that was rolled-back to.
+	RollbackSource *int64      `json:"rollbackSource,omitempty"`// Only present if this version is the result of a rollback, and will be the; version number of the Remote Config template that was rolled-back to.
 	UpdateOrigin   *Update     `json:"updateOrigin"`            // Where the update action originated.
 	UpdateTime     *string     `json:"updateTime,omitempty"`    // When the Remote Config template was written to the Remote Config server.
 	UpdateType     *Update     `json:"updateType"`              // What type of update was made.
 	UpdateUser     *UpdateUser `json:"updateUser,omitempty"`    // Aggregation of all metadata fields about the account that performed the update.
-	VersionNumber  *string     `json:"versionNumber,omitempty"` // The version number of the version's corresponding Remote Config template.
+	VersionNumber  *int64      `json:"versionNumber,omitempty"` // The version number of the version's corresponding Remote Config template.
 }
 
 // Aggregation of all metadata fields about the account that performed the update.


### PR DESCRIPTION
Uses int64 values with the updated JSON schema. Makes using this library a bit less clunky.