### PR TITLE
fix: allow unmarshalling of 64 bit numbers as strings

### DIFF
--- a/cloud/audit/v1/log_entry_data.go
+++ b/cloud/audit/v1/log_entry_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,80 +17,80 @@ import "encoding/json"
 
 // The data within all Cloud Audit Logs log entry events.
 type LogEntryData struct {
-	InsertID         *string           `json:"insertId,omitempty"`        // A unique identifier for the log entry.
-	Labels           map[string]string `json:"labels,omitempty"`          // A set of user-defined (key, value) data that provides additional; information about the log entry.
-	LogName          *string           `json:"logName,omitempty"`         // The resource name of the log to which this log entry belongs.
-	Operation        *Operation        `json:"operation,omitempty"`       // Information about an operation associated with the log entry, if applicable.
-	ProtoPayload     *ProtoPayload     `json:"protoPayload,omitempty"`    // The log entry payload, which is always an AuditLog for Cloud Audit Log events.
-	ReceiveTimestamp *string           `json:"receiveTimestamp,omitempty"`// The time the log entry was received by Logging.
-	Resource         *Resource         `json:"resource,omitempty"`        // The monitored resource that produced this log entry.; ; Example: a log entry that reports a database error would be associated with; the monitored resource designating the particular database that reported; the error.
-	Severity         *Severity         `json:"severity"`                  // The severity of the log entry.
-	SpanID           *string           `json:"spanId,omitempty"`          // The span ID within the trace associated with the log entry, if any.; ; For Trace spans, this is the same format that the Trace API v2 uses: a; 16-character hexadecimal encoding of an 8-byte array, such as; `000000000000004a`.
-	Timestamp        *string           `json:"timestamp,omitempty"`       // The time the event described by the log entry occurred.
-	Trace            *string           `json:"trace,omitempty"`           // Resource name of the trace associated with the log entry, if any. If it; contains a relative resource name, the name is assumed to be relative to; `//tracing.googleapis.com`. Example:; `projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824`
+	InsertID         *string           `json:"insertId,omitempty"`         // A unique identifier for the log entry.
+	Labels           map[string]string `json:"labels,omitempty"`           // A set of user-defined (key, value) data that provides additional; information about the log entry.
+	LogName          *string           `json:"logName,omitempty"`          // The resource name of the log to which this log entry belongs.
+	Operation        *Operation        `json:"operation,omitempty"`        // Information about an operation associated with the log entry, if applicable.
+	ProtoPayload     *ProtoPayload     `json:"protoPayload,omitempty"`     // The log entry payload, which is always an AuditLog for Cloud Audit Log events.
+	ReceiveTimestamp *string           `json:"receiveTimestamp,omitempty"` // The time the log entry was received by Logging.
+	Resource         *Resource         `json:"resource,omitempty"`         // The monitored resource that produced this log entry.; ; Example: a log entry that reports a database error would be associated with; the monitored resource designating the particular database that reported; the error.
+	Severity         *Severity         `json:"severity"`                   // The severity of the log entry.
+	SpanID           *string           `json:"spanId,omitempty"`           // The span ID within the trace associated with the log entry, if any.; ; For Trace spans, this is the same format that the Trace API v2 uses: a; 16-character hexadecimal encoding of an 8-byte array, such as; `000000000000004a`.
+	Timestamp        *string           `json:"timestamp,omitempty"`        // The time the event described by the log entry occurred.
+	Trace            *string           `json:"trace,omitempty"`            // Resource name of the trace associated with the log entry, if any. If it; contains a relative resource name, the name is assumed to be relative to; `//tracing.googleapis.com`. Example:; `projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824`
 }
 
 // Information about an operation associated with the log entry, if applicable.
 type Operation struct {
-	First    *bool   `json:"first,omitempty"`   // True if this is the first log entry in the operation.
-	ID       *string `json:"id,omitempty"`      // An arbitrary operation identifier. Log entries with the same; identifier are assumed to be part of the same operation.
-	Last     *bool   `json:"last,omitempty"`    // True if this is the last log entry in the operation.
-	Producer *string `json:"producer,omitempty"`// An arbitrary producer identifier. The combination of `id` and; `producer` must be globally unique. Examples for `producer`:; `"MyDivision.MyBigCompany.com"`, `"github.com/MyProject/MyApplication"`.
+	First    *bool   `json:"first,omitempty"`    // True if this is the first log entry in the operation.
+	ID       *string `json:"id,omitempty"`       // An arbitrary operation identifier. Log entries with the same; identifier are assumed to be part of the same operation.
+	Last     *bool   `json:"last,omitempty"`     // True if this is the last log entry in the operation.
+	Producer *string `json:"producer,omitempty"` // An arbitrary producer identifier. The combination of `id` and; `producer` must be globally unique. Examples for `producer`:; `"MyDivision.MyBigCompany.com"`, `"github.com/MyProject/MyApplication"`.
 }
 
 // The log entry payload, which is always an AuditLog for Cloud Audit Log events.
 type ProtoPayload struct {
-	AuthenticationInfo    *AuthenticationInfo    `json:"authenticationInfo,omitempty"`   // Authentication information.
-	AuthorizationInfo     []AuthorizationInfo    `json:"authorizationInfo,omitempty"`    // Authorization information. If there are multiple; resources or permissions involved, then there is; one AuthorizationInfo element for each {resource, permission} tuple.
-	Metadata              *Metadata              `json:"metadata,omitempty"`             // Other service-specific data about the request, response, and other; information associated with the current audited event.
-	MethodName            *string                `json:"methodName,omitempty"`           // The name of the service method or operation.; For API calls, this should be the name of the API method.; For example,; ; "google.datastore.v1.Datastore.RunQuery"; "google.logging.v1.LoggingService.DeleteLog"
-	NumResponseItems      *int64                 `json:"numResponseItems,omitempty"`     // The number of items returned from a List or Query API method,; if applicable.
-	Request               *Request               `json:"request,omitempty"`              // The operation request. This may not include all request parameters,; such as those that are too large, privacy-sensitive, or duplicated; elsewhere in the log record.; It should never include user-generated data, such as file contents.; When the JSON object represented here has a proto equivalent, the proto; name will be indicated in the `@type` property.
-	RequestMetadata       *RequestMetadata       `json:"requestMetadata,omitempty"`      // Metadata about the operation.
-	ResourceLocation      *ResourceLocation      `json:"resourceLocation,omitempty"`     // The resource location information.
-	ResourceName          *string                `json:"resourceName,omitempty"`         // The resource or collection that is the target of the operation.; The name is a scheme-less URI, not including the API service name.; For example:; ; "shelves/SHELF_ID/books"; "shelves/SHELF_ID/books/BOOK_ID"
-	ResourceOriginalState *ResourceOriginalState `json:"resourceOriginalState,omitempty"`// The resource's original state before mutation. Present only for; operations which have successfully modified the targeted resource(s).; In general, this field should contain all changed fields, except those; that are already been included in `request`, `response`, `metadata` or; `service_data` fields.; When the JSON object represented here has a proto equivalent,; the proto name will be indicated in the `@type` property.
-	Response              *Response              `json:"response,omitempty"`             // The operation response. This may not include all response elements,; such as those that are too large, privacy-sensitive, or duplicated; elsewhere in the log record.; It should never include user-generated data, such as file contents.; When the JSON object represented here has a proto equivalent, the proto; name will be indicated in the `@type` property.
-	ServiceData           *ServiceData           `json:"serviceData,omitempty"`          // Deprecated, use `metadata` field instead.; Other service-specific data about the request, response, and other; activities.; When the JSON object represented here has a proto equivalent, the proto; name will be indicated in the `@type` property.
-	ServiceName           *string                `json:"serviceName,omitempty"`          // The name of the API service performing the operation. For example,; `"datastore.googleapis.com"`.
-	Status                *Status                `json:"status,omitempty"`               // The status of the overall operation.
+	AuthenticationInfo    *AuthenticationInfo    `json:"authenticationInfo,omitempty"`      // Authentication information.
+	AuthorizationInfo     []AuthorizationInfo    `json:"authorizationInfo,omitempty"`       // Authorization information. If there are multiple; resources or permissions involved, then there is; one AuthorizationInfo element for each {resource, permission} tuple.
+	Metadata              *Metadata              `json:"metadata,omitempty"`                // Other service-specific data about the request, response, and other; information associated with the current audited event.
+	MethodName            *string                `json:"methodName,omitempty"`              // The name of the service method or operation.; For API calls, this should be the name of the API method.; For example,; ; "google.datastore.v1.Datastore.RunQuery"; "google.logging.v1.LoggingService.DeleteLog"
+	NumResponseItems      *int64                 `json:"numResponseItems,string,omitempty"` // The number of items returned from a List or Query API method,; if applicable.
+	Request               *Request               `json:"request,omitempty"`                 // The operation request. This may not include all request parameters,; such as those that are too large, privacy-sensitive, or duplicated; elsewhere in the log record.; It should never include user-generated data, such as file contents.; When the JSON object represented here has a proto equivalent, the proto; name will be indicated in the `@type` property.
+	RequestMetadata       *RequestMetadata       `json:"requestMetadata,omitempty"`         // Metadata about the operation.
+	ResourceLocation      *ResourceLocation      `json:"resourceLocation,omitempty"`        // The resource location information.
+	ResourceName          *string                `json:"resourceName,omitempty"`            // The resource or collection that is the target of the operation.; The name is a scheme-less URI, not including the API service name.; For example:; ; "shelves/SHELF_ID/books"; "shelves/SHELF_ID/books/BOOK_ID"
+	ResourceOriginalState *ResourceOriginalState `json:"resourceOriginalState,omitempty"`   // The resource's original state before mutation. Present only for; operations which have successfully modified the targeted resource(s).; In general, this field should contain all changed fields, except those; that are already been included in `request`, `response`, `metadata` or; `service_data` fields.; When the JSON object represented here has a proto equivalent,; the proto name will be indicated in the `@type` property.
+	Response              *Response              `json:"response,omitempty"`                // The operation response. This may not include all response elements,; such as those that are too large, privacy-sensitive, or duplicated; elsewhere in the log record.; It should never include user-generated data, such as file contents.; When the JSON object represented here has a proto equivalent, the proto; name will be indicated in the `@type` property.
+	ServiceData           *ServiceData           `json:"serviceData,omitempty"`             // Deprecated, use `metadata` field instead.; Other service-specific data about the request, response, and other; activities.; When the JSON object represented here has a proto equivalent, the proto; name will be indicated in the `@type` property.
+	ServiceName           *string                `json:"serviceName,omitempty"`             // The name of the API service performing the operation. For example,; `"datastore.googleapis.com"`.
+	Status                *Status                `json:"status,omitempty"`                  // The status of the overall operation.
 }
 
 // Authentication information.
 type AuthenticationInfo struct {
-	AuthoritySelector            *string                                `json:"authoritySelector,omitempty"`           // The authority selector specified by the requestor, if any.; It is not guaranteed that the principal was allowed to use this authority.
-	PrincipalEmail               *string                                `json:"principalEmail,omitempty"`              // The email address of the authenticated user (or service account on behalf; of third party principal) making the request. For privacy reasons, the; principal email address is redacted for all read-only operations that fail; with a "permission denied" error.
-	PrincipalSubject             *string                                `json:"principalSubject,omitempty"`            // String representation of identity of requesting party.; Populated for both first and third party identities.
-	ServiceAccountDelegationInfo []ServiceAccountDelegationInfo         `json:"serviceAccountDelegationInfo,omitempty"`// Identity delegation history of an authenticated service account that makes; the request. It contains information on the real authorities that try to; access GCP resources by delegating on a service account. When multiple; authorities present, they are guaranteed to be sorted based on the original; ordering of the identity delegation events.
-	ServiceAccountKeyName        *string                                `json:"serviceAccountKeyName,omitempty"`       // The name of the service account key used to create or exchange; credentials for authenticating the service account making the request.; This is a scheme-less URI full resource name. For example:; ; "//iam.googleapis.com/projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}"
-	ThirdPartyPrincipal          *AuthenticationInfoThirdPartyPrincipal `json:"thirdPartyPrincipal,omitempty"`         // The third party identification (if any) of the authenticated user making; the request.; When the JSON object represented here has a proto equivalent, the proto; name will be indicated in the `@type` property.
+	AuthoritySelector            *string                                `json:"authoritySelector,omitempty"`            // The authority selector specified by the requestor, if any.; It is not guaranteed that the principal was allowed to use this authority.
+	PrincipalEmail               *string                                `json:"principalEmail,omitempty"`               // The email address of the authenticated user (or service account on behalf; of third party principal) making the request. For privacy reasons, the; principal email address is redacted for all read-only operations that fail; with a "permission denied" error.
+	PrincipalSubject             *string                                `json:"principalSubject,omitempty"`             // String representation of identity of requesting party.; Populated for both first and third party identities.
+	ServiceAccountDelegationInfo []ServiceAccountDelegationInfo         `json:"serviceAccountDelegationInfo,omitempty"` // Identity delegation history of an authenticated service account that makes; the request. It contains information on the real authorities that try to; access GCP resources by delegating on a service account. When multiple; authorities present, they are guaranteed to be sorted based on the original; ordering of the identity delegation events.
+	ServiceAccountKeyName        *string                                `json:"serviceAccountKeyName,omitempty"`        // The name of the service account key used to create or exchange; credentials for authenticating the service account making the request.; This is a scheme-less URI full resource name. For example:; ; "//iam.googleapis.com/projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}"
+	ThirdPartyPrincipal          *AuthenticationInfoThirdPartyPrincipal `json:"thirdPartyPrincipal,omitempty"`          // The third party identification (if any) of the authenticated user making; the request.; When the JSON object represented here has a proto equivalent, the proto; name will be indicated in the `@type` property.
 }
 
 // Identity delegation history of an authenticated service account.
 type ServiceAccountDelegationInfo struct {
-	FirstPartyPrincipal *FirstPartyPrincipal                             `json:"firstPartyPrincipal,omitempty"`// First party (Google) identity as the real authority.
-	ThirdPartyPrincipal *ServiceAccountDelegationInfoThirdPartyPrincipal `json:"thirdPartyPrincipal,omitempty"`// Third party identity as the real authority.
+	FirstPartyPrincipal *FirstPartyPrincipal                             `json:"firstPartyPrincipal,omitempty"` // First party (Google) identity as the real authority.
+	ThirdPartyPrincipal *ServiceAccountDelegationInfoThirdPartyPrincipal `json:"thirdPartyPrincipal,omitempty"` // Third party identity as the real authority.
 }
 
 // First party (Google) identity as the real authority.
 type FirstPartyPrincipal struct {
-	PrincipalEmail  *string          `json:"principalEmail,omitempty"` // The email address of a Google account.
-	ServiceMetadata *ServiceMetadata `json:"serviceMetadata,omitempty"`// Metadata about the service that uses the service account.
+	PrincipalEmail  *string          `json:"principalEmail,omitempty"`  // The email address of a Google account.
+	ServiceMetadata *ServiceMetadata `json:"serviceMetadata,omitempty"` // Metadata about the service that uses the service account.
 }
 
 // Metadata about the service that uses the service account.
 type ServiceMetadata struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"`// Unordered map of dynamically typed values.
+	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
 // Third party identity as the real authority.
 type ServiceAccountDelegationInfoThirdPartyPrincipal struct {
-	ThirdPartyClaims *ThirdPartyClaims `json:"thirdPartyClaims,omitempty"`// Metadata about third party identity.
+	ThirdPartyClaims *ThirdPartyClaims `json:"thirdPartyClaims,omitempty"` // Metadata about third party identity.
 }
 
 // Metadata about third party identity.
 type ThirdPartyClaims struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"`// Unordered map of dynamically typed values.
+	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
 // The third party identification (if any) of the authenticated user making
@@ -98,15 +98,15 @@ type ThirdPartyClaims struct {
 // When the JSON object represented here has a proto equivalent, the proto
 // name will be indicated in the `@type` property.
 type AuthenticationInfoThirdPartyPrincipal struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"`// Unordered map of dynamically typed values.
+	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
 // Authorization information for the operation.
 type AuthorizationInfo struct {
-	Granted            *bool               `json:"granted,omitempty"`           // Whether or not authorization for `resource` and `permission`; was granted.
-	Permission         *string             `json:"permission,omitempty"`        // The required IAM permission.
-	Resource           *string             `json:"resource,omitempty"`          // The resource being accessed, as a REST-style string. For example:; ; bigquery.googleapis.com/projects/PROJECTID/datasets/DATASETID
-	ResourceAttributes *ResourceAttributes `json:"resourceAttributes,omitempty"`// Resource attributes used in IAM condition evaluation. This field contains; resource attributes like resource type and resource name.; ; To get the whole view of the attributes used in IAM; condition evaluation, the user must also look into; `AuditLogData.request_metadata.request_attributes`.
+	Granted            *bool               `json:"granted,omitempty"`            // Whether or not authorization for `resource` and `permission`; was granted.
+	Permission         *string             `json:"permission,omitempty"`         // The required IAM permission.
+	Resource           *string             `json:"resource,omitempty"`           // The resource being accessed, as a REST-style string. For example:; ; bigquery.googleapis.com/projects/PROJECTID/datasets/DATASETID
+	ResourceAttributes *ResourceAttributes `json:"resourceAttributes,omitempty"` // Resource attributes used in IAM condition evaluation. This field contains; resource attributes like resource type and resource name.; ; To get the whole view of the attributes used in IAM; condition evaluation, the user must also look into; `AuditLogData.request_metadata.request_attributes`.
 }
 
 // Resource attributes used in IAM condition evaluation. This field contains
@@ -116,16 +116,16 @@ type AuthorizationInfo struct {
 // condition evaluation, the user must also look into
 // `AuditLogData.request_metadata.request_attributes`.
 type ResourceAttributes struct {
-	Labels  map[string]string `json:"labels,omitempty"` // The labels or tags on the resource, such as AWS resource tags and; Kubernetes resource labels.
-	Name    *string           `json:"name,omitempty"`   // The stable identifier (name) of a resource on the `service`. A resource; can be logically identified as "//{resource.service}/{resource.name}".; The differences between a resource name and a URI are:; ; *   Resource name is a logical identifier, independent of network; protocol and API version. For example,; `//pubsub.googleapis.com/projects/123/topics/news-feed`.; *   URI often includes protocol and version information, so it can; be used directly by applications. For example,; `https://pubsub.googleapis.com/v1/projects/123/topics/news-feed`.; ; See https://cloud.google.com/apis/design/resource_names for details.
-	Service *string           `json:"service,omitempty"`// The name of the service that this resource belongs to, such as; `pubsub.googleapis.com`. The service may be different from the DNS; hostname that actually serves the request.
-	Type    *string           `json:"type,omitempty"`   // The type of the resource. The syntax is platform-specific because; different platforms define their resources differently.; ; For Google APIs, the type format must be "{service}/{kind}".
+	Labels  map[string]string `json:"labels,omitempty"`  // The labels or tags on the resource, such as AWS resource tags and; Kubernetes resource labels.
+	Name    *string           `json:"name,omitempty"`    // The stable identifier (name) of a resource on the `service`. A resource; can be logically identified as "//{resource.service}/{resource.name}".; The differences between a resource name and a URI are:; ; *   Resource name is a logical identifier, independent of network; protocol and API version. For example,; `//pubsub.googleapis.com/projects/123/topics/news-feed`.; *   URI often includes protocol and version information, so it can; be used directly by applications. For example,; `https://pubsub.googleapis.com/v1/projects/123/topics/news-feed`.; ; See https://cloud.google.com/apis/design/resource_names for details.
+	Service *string           `json:"service,omitempty"` // The name of the service that this resource belongs to, such as; `pubsub.googleapis.com`. The service may be different from the DNS; hostname that actually serves the request.
+	Type    *string           `json:"type,omitempty"`    // The type of the resource. The syntax is platform-specific because; different platforms define their resources differently.; ; For Google APIs, the type format must be "{service}/{kind}".
 }
 
 // Other service-specific data about the request, response, and other
 // information associated with the current audited event.
 type Metadata struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"`// Unordered map of dynamically typed values.
+	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
 // The operation request. This may not include all request parameters,
@@ -135,16 +135,16 @@ type Metadata struct {
 // When the JSON object represented here has a proto equivalent, the proto
 // name will be indicated in the `@type` property.
 type Request struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"`// Unordered map of dynamically typed values.
+	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
 // Metadata about the operation.
 type RequestMetadata struct {
-	CallerIP                *string                `json:"callerIp,omitempty"`               // The IP address of the caller.; For caller from internet, this will be public IPv4 or IPv6 address.; For caller from a Compute Engine VM with external IP address, this; will be the VM's external IP address. For caller from a Compute; Engine VM without external IP address, if the VM is in the same; organization (or project) as the accessed resource, `caller_ip` will; be the VM's internal IPv4 address, otherwise the `caller_ip` will be; redacted to "gce-internal-ip".; See https://cloud.google.com/compute/docs/vpc/ for more information.
-	CallerNetwork           *string                `json:"callerNetwork,omitempty"`          // The network of the caller.; Set only if the network host project is part of the same GCP organization; (or project) as the accessed resource.; See https://cloud.google.com/compute/docs/vpc/ for more information.; This is a scheme-less URI full resource name. For example:; ; "//compute.googleapis.com/projects/PROJECT_ID/global/networks/NETWORK_ID"
-	CallerSuppliedUserAgent *string                `json:"callerSuppliedUserAgent,omitempty"`// The user agent of the caller.; This information is not authenticated and should be treated accordingly.; For example:; ; +   `google-api-python-client/1.4.0`:; The request was made by the Google API client for Python.; +   `Cloud SDK Command Line Tool apitools-client/1.0 gcloud/0.9.62`:; The request was made by the Google Cloud SDK CLI (gcloud).; +   `AppEngine-Google; (+http://code.google.com/appengine; appid:; s~my-project`:; The request was made from the `my-project` App Engine app.
-	DestinationAttributes   *DestinationAttributes `json:"destinationAttributes,omitempty"`  // The destination of a network activity, such as accepting a TCP connection.; In a multi hop network activity, the destination represents the receiver of; the last hop. Only two fields are used in this message, Peer.port and; Peer.ip. These fields are optionally populated by those services utilizing; the IAM condition feature.
-	RequestAttributes       *RequestAttributes     `json:"requestAttributes,omitempty"`      // Request attributes used in IAM condition evaluation. This field contains; request attributes like request time and access levels associated with; the request.; ; ; To get the whole view of the attributes used in IAM; condition evaluation, the user must also look into; `AuditLog.authentication_info.resource_attributes`.
+	CallerIP                *string                `json:"callerIp,omitempty"`                // The IP address of the caller.; For caller from internet, this will be public IPv4 or IPv6 address.; For caller from a Compute Engine VM with external IP address, this; will be the VM's external IP address. For caller from a Compute; Engine VM without external IP address, if the VM is in the same; organization (or project) as the accessed resource, `caller_ip` will; be the VM's internal IPv4 address, otherwise the `caller_ip` will be; redacted to "gce-internal-ip".; See https://cloud.google.com/compute/docs/vpc/ for more information.
+	CallerNetwork           *string                `json:"callerNetwork,omitempty"`           // The network of the caller.; Set only if the network host project is part of the same GCP organization; (or project) as the accessed resource.; See https://cloud.google.com/compute/docs/vpc/ for more information.; This is a scheme-less URI full resource name. For example:; ; "//compute.googleapis.com/projects/PROJECT_ID/global/networks/NETWORK_ID"
+	CallerSuppliedUserAgent *string                `json:"callerSuppliedUserAgent,omitempty"` // The user agent of the caller.; This information is not authenticated and should be treated accordingly.; For example:; ; +   `google-api-python-client/1.4.0`:; The request was made by the Google API client for Python.; +   `Cloud SDK Command Line Tool apitools-client/1.0 gcloud/0.9.62`:; The request was made by the Google Cloud SDK CLI (gcloud).; +   `AppEngine-Google; (+http://code.google.com/appengine; appid:; s~my-project`:; The request was made from the `my-project` App Engine app.
+	DestinationAttributes   *DestinationAttributes `json:"destinationAttributes,omitempty"`   // The destination of a network activity, such as accepting a TCP connection.; In a multi hop network activity, the destination represents the receiver of; the last hop. Only two fields are used in this message, Peer.port and; Peer.ip. These fields are optionally populated by those services utilizing; the IAM condition feature.
+	RequestAttributes       *RequestAttributes     `json:"requestAttributes,omitempty"`       // Request attributes used in IAM condition evaluation. This field contains; request attributes like request time and access levels associated with; the request.; ; ; To get the whole view of the attributes used in IAM; condition evaluation, the user must also look into; `AuditLog.authentication_info.resource_attributes`.
 }
 
 // The destination of a network activity, such as accepting a TCP connection.
@@ -153,11 +153,11 @@ type RequestMetadata struct {
 // Peer.ip. These fields are optionally populated by those services utilizing
 // the IAM condition feature.
 type DestinationAttributes struct {
-	IP         *string           `json:"ip,omitempty"`        // The IP address of the peer.
-	Labels     map[string]string `json:"labels,omitempty"`    // The labels associated with the peer.
-	Port       *int64            `json:"port,omitempty"`      // The network port of the peer.
-	Principal  *string           `json:"principal,omitempty"` // The identity of this peer. Similar to `Request.auth.principal`, but; relative to the peer instead of the request. For example, the; idenity associated with a load balancer that forwared the request.
-	RegionCode *string           `json:"regionCode,omitempty"`// The CLDR country/region code associated with the above IP address.; If the IP address is private, the `region_code` should reflect the; physical location where this peer is running.
+	IP         *string           `json:"ip,omitempty"`          // The IP address of the peer.
+	Labels     map[string]string `json:"labels,omitempty"`      // The labels associated with the peer.
+	Port       *int64            `json:"port,string,omitempty"` // The network port of the peer.
+	Principal  *string           `json:"principal,omitempty"`   // The identity of this peer. Similar to `Request.auth.principal`, but; relative to the peer instead of the request. For example, the; idenity associated with a load balancer that forwared the request.
+	RegionCode *string           `json:"regionCode,omitempty"`  // The CLDR country/region code associated with the above IP address.; If the IP address is private, the `region_code` should reflect the; physical location where this peer is running.
 }
 
 // Request attributes used in IAM condition evaluation. This field contains
@@ -169,28 +169,28 @@ type DestinationAttributes struct {
 // condition evaluation, the user must also look into
 // `AuditLog.authentication_info.resource_attributes`.
 type RequestAttributes struct {
-	Auth     *Auth             `json:"auth,omitempty"`    // The request authentication. May be absent for unauthenticated requests.; Derived from the HTTP request `Authorization` header or equivalent.
-	Headers  map[string]string `json:"headers,omitempty"` // The HTTP request headers. If multiple headers share the same key, they; must be merged according to the HTTP spec. All header keys must be; lowercased, because HTTP header keys are case-insensitive.
-	Host     *string           `json:"host,omitempty"`    // The HTTP request `Host` header value.
-	ID       *string           `json:"id,omitempty"`      // The unique ID for a request, which can be propagated to downstream; systems. The ID should have low probability of collision; within a single day for a specific service.
-	Method   *string           `json:"method,omitempty"`  // The HTTP request method, such as `GET`, `POST`.
-	Path     *string           `json:"path,omitempty"`    // The HTTP URL path.
-	Protocol *string           `json:"protocol,omitempty"`// The network protocol used with the request, such as "http/1.1",; "spdy/3", "h2", "h2c", "webrtc", "tcp", "udp", "quic". See; ; https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids; for details.
-	Query    *string           `json:"query,omitempty"`   // The HTTP URL query in the format of `name1=value1&name2=value2`, as it; appears in the first line of the HTTP request. No decoding is performed.
-	Reason   *string           `json:"reason,omitempty"`  // A special parameter for request reason. It is used by security systems; to associate auditing information with a request.
-	Scheme   *string           `json:"scheme,omitempty"`  // The HTTP URL scheme, such as `http` and `https`.
-	Size     *int64            `json:"size,omitempty"`    // The HTTP request size in bytes. If unknown, it must be -1.
-	Time     *string           `json:"time,omitempty"`    // The timestamp when the `destination` service receives the first byte of; the request.
+	Auth     *Auth             `json:"auth,omitempty"`        // The request authentication. May be absent for unauthenticated requests.; Derived from the HTTP request `Authorization` header or equivalent.
+	Headers  map[string]string `json:"headers,omitempty"`     // The HTTP request headers. If multiple headers share the same key, they; must be merged according to the HTTP spec. All header keys must be; lowercased, because HTTP header keys are case-insensitive.
+	Host     *string           `json:"host,omitempty"`        // The HTTP request `Host` header value.
+	ID       *string           `json:"id,omitempty"`          // The unique ID for a request, which can be propagated to downstream; systems. The ID should have low probability of collision; within a single day for a specific service.
+	Method   *string           `json:"method,omitempty"`      // The HTTP request method, such as `GET`, `POST`.
+	Path     *string           `json:"path,omitempty"`        // The HTTP URL path.
+	Protocol *string           `json:"protocol,omitempty"`    // The network protocol used with the request, such as "http/1.1",; "spdy/3", "h2", "h2c", "webrtc", "tcp", "udp", "quic". See; ; https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids; for details.
+	Query    *string           `json:"query,omitempty"`       // The HTTP URL query in the format of `name1=value1&name2=value2`, as it; appears in the first line of the HTTP request. No decoding is performed.
+	Reason   *string           `json:"reason,omitempty"`      // A special parameter for request reason. It is used by security systems; to associate auditing information with a request.
+	Scheme   *string           `json:"scheme,omitempty"`      // The HTTP URL scheme, such as `http` and `https`.
+	Size     *int64            `json:"size,string,omitempty"` // The HTTP request size in bytes. If unknown, it must be -1.
+	Time     *string           `json:"time,omitempty"`        // The timestamp when the `destination` service receives the first byte of; the request.
 }
 
 // The request authentication. May be absent for unauthenticated requests.
 // Derived from the HTTP request `Authorization` header or equivalent.
 type Auth struct {
-	AccessLevels []string `json:"accessLevels,omitempty"`// A list of access level resource names that allow resources to be; accessed by authenticated requester. It is part of Secure GCP processing; for the incoming request. An access level string has the format:; "//{api_service_name}/accessPolicies/{policy_id}/accessLevels/{short_name}"; ; Example:; "//accesscontextmanager.googleapis.com/accessPolicies/MY_POLICY_ID/accessLevels/MY_LEVEL"
-	Audiences    []string `json:"audiences,omitempty"`   // The intended audience(s) for this authentication information. Reflects; the audience (`aud`) claim within a JWT. The audience; value(s) depends on the `issuer`, but typically include one or more of; the following pieces of information:; ; *  The services intended to receive the credential such as; ["pubsub.googleapis.com", "storage.googleapis.com"]; *  A set of service-based scopes. For example,; ["https://www.googleapis.com/auth/cloud-platform"]; *  The client id of an app, such as the Firebase project id for JWTs; from Firebase Auth.; ; Consult the documentation for the credential issuer to determine the; information provided.
-	Claims       *Claims  `json:"claims,omitempty"`      // Structured claims presented with the credential. JWTs include; `{key: value}` pairs for standard and private claims. The following; is a subset of the standard required and optional claims that would; typically be presented for a Google-based JWT:; ; {'iss': 'accounts.google.com',; 'sub': '113289723416554971153',; 'aud': ['123456789012', 'pubsub.googleapis.com'],; 'azp': '123456789012.apps.googleusercontent.com',; 'email': 'jsmith@example.com',; 'iat': 1353601026,; 'exp': 1353604926}; ; SAML assertions are similarly specified, but with an identity provider; dependent structure.
-	Presenter    *string  `json:"presenter,omitempty"`   // The authorized presenter of the credential. Reflects the optional; Authorized Presenter (`azp`) claim within a JWT or the; OAuth client id. For example, a Google Cloud Platform client id looks; as follows: "123456789012.apps.googleusercontent.com".
-	Principal    *string  `json:"principal,omitempty"`   // The authenticated principal. Reflects the issuer (`iss`) and subject; (`sub`) claims within a JWT. The issuer and subject should be `/`; delimited, with `/` percent-encoded within the subject fragment. For; Google accounts, the principal format is:; "https://accounts.google.com/{id}"
+	AccessLevels []string `json:"accessLevels,omitempty"` // A list of access level resource names that allow resources to be; accessed by authenticated requester. It is part of Secure GCP processing; for the incoming request. An access level string has the format:; "//{api_service_name}/accessPolicies/{policy_id}/accessLevels/{short_name}"; ; Example:; "//accesscontextmanager.googleapis.com/accessPolicies/MY_POLICY_ID/accessLevels/MY_LEVEL"
+	Audiences    []string `json:"audiences,omitempty"`    // The intended audience(s) for this authentication information. Reflects; the audience (`aud`) claim within a JWT. The audience; value(s) depends on the `issuer`, but typically include one or more of; the following pieces of information:; ; *  The services intended to receive the credential such as; ["pubsub.googleapis.com", "storage.googleapis.com"]; *  A set of service-based scopes. For example,; ["https://www.googleapis.com/auth/cloud-platform"]; *  The client id of an app, such as the Firebase project id for JWTs; from Firebase Auth.; ; Consult the documentation for the credential issuer to determine the; information provided.
+	Claims       *Claims  `json:"claims,omitempty"`       // Structured claims presented with the credential. JWTs include; `{key: value}` pairs for standard and private claims. The following; is a subset of the standard required and optional claims that would; typically be presented for a Google-based JWT:; ; {'iss': 'accounts.google.com',; 'sub': '113289723416554971153',; 'aud': ['123456789012', 'pubsub.googleapis.com'],; 'azp': '123456789012.apps.googleusercontent.com',; 'email': 'jsmith@example.com',; 'iat': 1353601026,; 'exp': 1353604926}; ; SAML assertions are similarly specified, but with an identity provider; dependent structure.
+	Presenter    *string  `json:"presenter,omitempty"`    // The authorized presenter of the credential. Reflects the optional; Authorized Presenter (`azp`) claim within a JWT or the; OAuth client id. For example, a Google Cloud Platform client id looks; as follows: "123456789012.apps.googleusercontent.com".
+	Principal    *string  `json:"principal,omitempty"`    // The authenticated principal. Reflects the issuer (`iss`) and subject; (`sub`) claims within a JWT. The issuer and subject should be `/`; delimited, with `/` percent-encoded within the subject fragment. For; Google accounts, the principal format is:; "https://accounts.google.com/{id}"
 }
 
 // Structured claims presented with the credential. JWTs include
@@ -209,13 +209,13 @@ type Auth struct {
 // SAML assertions are similarly specified, but with an identity provider
 // dependent structure.
 type Claims struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"`// Unordered map of dynamically typed values.
+	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
 // The resource location information.
 type ResourceLocation struct {
-	CurrentLocations  []string `json:"currentLocations,omitempty"` // The locations of a resource after the execution of the operation.; Requests to create or delete a location based resource must populate; the 'current_locations' field and not the 'original_locations' field.; For example:; ; "europe-west1-a"; "us-east1"; "nam3"
-	OriginalLocations []string `json:"originalLocations,omitempty"`// The locations of a resource prior to the execution of the operation.; Requests that mutate the resource's location must populate both the; 'original_locations' as well as the 'current_locations' fields.; For example:; ; "europe-west1-a"; "us-east1"; "nam3"
+	CurrentLocations  []string `json:"currentLocations,omitempty"`  // The locations of a resource after the execution of the operation.; Requests to create or delete a location based resource must populate; the 'current_locations' field and not the 'original_locations' field.; For example:; ; "europe-west1-a"; "us-east1"; "nam3"
+	OriginalLocations []string `json:"originalLocations,omitempty"` // The locations of a resource prior to the execution of the operation.; Requests that mutate the resource's location must populate both the; 'original_locations' as well as the 'current_locations' fields.; For example:; ; "europe-west1-a"; "us-east1"; "nam3"
 }
 
 // The resource's original state before mutation. Present only for
@@ -226,7 +226,7 @@ type ResourceLocation struct {
 // When the JSON object represented here has a proto equivalent,
 // the proto name will be indicated in the `@type` property.
 type ResourceOriginalState struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"`// Unordered map of dynamically typed values.
+	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
 // The operation response. This may not include all response elements,
@@ -236,7 +236,7 @@ type ResourceOriginalState struct {
 // When the JSON object represented here has a proto equivalent, the proto
 // name will be indicated in the `@type` property.
 type Response struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"`// Unordered map of dynamically typed values.
+	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
 // Deprecated, use `metadata` field instead.
@@ -245,14 +245,14 @@ type Response struct {
 // When the JSON object represented here has a proto equivalent, the proto
 // name will be indicated in the `@type` property.
 type ServiceData struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"`// Unordered map of dynamically typed values.
+	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
 // The status of the overall operation.
 type Status struct {
-	Code    *int64   `json:"code,omitempty"`   // The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-	Details []Detail `json:"details,omitempty"`// A list of messages that carry the error details.  There is a common set of; message types for APIs to use.
-	Message *string  `json:"message,omitempty"`// A developer-facing error message, which should be in English. Any; user-facing error message should be localized and sent in the; [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+	Code    *int64   `json:"code,string,omitempty"` // The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+	Details []Detail `json:"details,omitempty"`     // A list of messages that carry the error details.  There is a common set of; message types for APIs to use.
+	Message *string  `json:"message,omitempty"`     // A developer-facing error message, which should be in English. Any; user-facing error message should be localized and sent in the; [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
 }
 
 // `Any` contains an arbitrary serialized protocol buffer message along with a
@@ -335,8 +335,8 @@ type Status struct {
 // "value": "1.212s"
 // }
 type Detail struct {
-	TypeURL *string `json:"typeUrl,omitempty"`// A URL/resource name that uniquely identifies the type of the serialized; protocol buffer message. This string must contain at least; one "/" character. The last segment of the URL's path must represent; the fully qualified name of the type (as in; `path/google.protobuf.Duration`). The name should be in a canonical form; (e.g., leading "." is not accepted).; ; In practice, teams usually precompile into the binary all types that they; expect it to use in the context of Any. However, for URLs which use the; scheme `http`, `https`, or no scheme, one can optionally set up a type; server that maps type URLs to message definitions as follows:; ; * If no scheme is provided, `https` is assumed.; * An HTTP GET on the URL must yield a [google.protobuf.Type][]; value in binary format, or produce an error.; * Applications are allowed to cache lookup results based on the; URL, or have them precompiled into a binary to avoid any; lookup. Therefore, binary compatibility needs to be preserved; on changes to types. (Use versioned type names to manage; breaking changes.); ; Note: this functionality is not currently available in the official; protobuf release, and it is not used for type URLs beginning with; type.googleapis.com.; ; Schemes other than `http`, `https` (or the empty scheme) might be; used with implementation specific semantics.
-	Value   *string `json:"value,omitempty"`  // Must be a valid serialized protocol buffer of the above specified type.
+	TypeURL *string `json:"typeUrl,omitempty"` // A URL/resource name that uniquely identifies the type of the serialized; protocol buffer message. This string must contain at least; one "/" character. The last segment of the URL's path must represent; the fully qualified name of the type (as in; `path/google.protobuf.Duration`). The name should be in a canonical form; (e.g., leading "." is not accepted).; ; In practice, teams usually precompile into the binary all types that they; expect it to use in the context of Any. However, for URLs which use the; scheme `http`, `https`, or no scheme, one can optionally set up a type; server that maps type URLs to message definitions as follows:; ; * If no scheme is provided, `https` is assumed.; * An HTTP GET on the URL must yield a [google.protobuf.Type][]; value in binary format, or produce an error.; * Applications are allowed to cache lookup results based on the; URL, or have them precompiled into a binary to avoid any; lookup. Therefore, binary compatibility needs to be preserved; on changes to types. (Use versioned type names to manage; breaking changes.); ; Note: this functionality is not currently available in the official; protobuf release, and it is not used for type URLs beginning with; type.googleapis.com.; ; Schemes other than `http`, `https` (or the empty scheme) might be; used with implementation specific semantics.
+	Value   *string `json:"value,omitempty"`   // Must be a valid serialized protocol buffer of the above specified type.
 }
 
 // The monitored resource that produced this log entry.
@@ -345,21 +345,22 @@ type Detail struct {
 // the monitored resource designating the particular database that reported
 // the error.
 type Resource struct {
-	Labels map[string]string `json:"labels,omitempty"`// Values for all of the labels listed in the associated monitored; resource descriptor. For example, Compute Engine VM instances use the; labels `"project_id"`, `"instance_id"`, and `"zone"`.
-	Type   *string           `json:"type,omitempty"`  // Required. The monitored resource type. For example, the type of a; Compute Engine VM instance is `gce_instance`.
+	Labels map[string]string `json:"labels,omitempty"` // Values for all of the labels listed in the associated monitored; resource descriptor. For example, Compute Engine VM instances use the; labels `"project_id"`, `"instance_id"`, and `"zone"`.
+	Type   *string           `json:"type,omitempty"`   // Required. The monitored resource type. For example, the type of a; Compute Engine VM instance is `gce_instance`.
 }
 
 type InsertID string
+
 const (
-	Alert InsertID = "ALERT"
-	Critical InsertID = "CRITICAL"
-	Debug InsertID = "DEBUG"
-	Default InsertID = "DEFAULT"
+	Alert     InsertID = "ALERT"
+	Critical  InsertID = "CRITICAL"
+	Debug     InsertID = "DEBUG"
+	Default   InsertID = "DEFAULT"
 	Emergency InsertID = "EMERGENCY"
-	Error InsertID = "ERROR"
-	Info InsertID = "INFO"
-	Notice InsertID = "NOTICE"
-	Warning InsertID = "WARNING"
+	Error     InsertID = "ERROR"
+	Info      InsertID = "INFO"
+	Notice    InsertID = "NOTICE"
+	Warning   InsertID = "WARNING"
 )
 
 // The severity of the log entry.

--- a/cloud/audit/v1/log_entry_data.go
+++ b/cloud/audit/v1/log_entry_data.go
@@ -20,8 +20,8 @@ type LogEntryData struct {
 	InsertID         *string           `json:"insertId,omitempty"`         // A unique identifier for the log entry.
 	Labels           map[string]string `json:"labels,omitempty"`           // A set of user-defined (key, value) data that provides additional; information about the log entry.
 	LogName          *string           `json:"logName,omitempty"`          // The resource name of the log to which this log entry belongs.
-	Operation        *Operation        `json:"operation,omitempty"`        // Information about an operation associated with the log entry, if applicable.
-	ProtoPayload     *ProtoPayload     `json:"protoPayload,omitempty"`     // The log entry payload, which is always an AuditLog for Cloud Audit Log events.
+	Operation        *Operation        `json:"operation,omitempty"`        // Information about an operation associated with the log entry, if; applicable.
+	ProtoPayload     *ProtoPayload     `json:"protoPayload,omitempty"`     // The log entry payload, which is always an AuditLog for Cloud Audit Log; events.
 	ReceiveTimestamp *string           `json:"receiveTimestamp,omitempty"` // The time the log entry was received by Logging.
 	Resource         *Resource         `json:"resource,omitempty"`         // The monitored resource that produced this log entry.; ; Example: a log entry that reports a database error would be associated with; the monitored resource designating the particular database that reported; the error.
 	Severity         *Severity         `json:"severity"`                   // The severity of the log entry.
@@ -30,7 +30,8 @@ type LogEntryData struct {
 	Trace            *string           `json:"trace,omitempty"`            // Resource name of the trace associated with the log entry, if any. If it; contains a relative resource name, the name is assumed to be relative to; `//tracing.googleapis.com`. Example:; `projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824`
 }
 
-// Information about an operation associated with the log entry, if applicable.
+// Information about an operation associated with the log entry, if
+// applicable.
 type Operation struct {
 	First    *bool   `json:"first,omitempty"`    // True if this is the first log entry in the operation.
 	ID       *string `json:"id,omitempty"`       // An arbitrary operation identifier. Log entries with the same; identifier are assumed to be part of the same operation.
@@ -38,7 +39,8 @@ type Operation struct {
 	Producer *string `json:"producer,omitempty"` // An arbitrary producer identifier. The combination of `id` and; `producer` must be globally unique. Examples for `producer`:; `"MyDivision.MyBigCompany.com"`, `"github.com/MyProject/MyApplication"`.
 }
 
-// The log entry payload, which is always an AuditLog for Cloud Audit Log events.
+// The log entry payload, which is always an AuditLog for Cloud Audit Log
+// events.
 type ProtoPayload struct {
 	AuthenticationInfo    *AuthenticationInfo    `json:"authenticationInfo,omitempty"`      // Authentication information.
 	AuthorizationInfo     []AuthorizationInfo    `json:"authorizationInfo,omitempty"`       // Authorization information. If there are multiple; resources or permissions involved, then there is; one AuthorizationInfo element for each {resource, permission} tuple.

--- a/cloud/cloudbuild/v1/build_event_data.go
+++ b/cloud/cloudbuild/v1/build_event_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,36 +17,36 @@ import "encoding/json"
 
 // Build event data for Google Cloud Platform API operations.
 type BuildEventData struct {
-	Artifacts        *Artifacts             `json:"artifacts,omitempty"`       // Artifacts produced by the build that should be uploaded upon; successful completion of all build steps.
-	BuildTriggerID   *string                `json:"buildTriggerId,omitempty"`  // The ID of the `BuildTrigger` that triggered this build, if it; was triggered automatically.
-	CreateTime       *string                `json:"createTime,omitempty"`      // Time at which the request to create the build was received.
-	FinishTime       *string                `json:"finishTime,omitempty"`      // Time at which execution of the build was finished.; ; The difference between finish_time and start_time is the duration of the; build's execution.
-	ID               *string                `json:"id,omitempty"`              // Unique identifier of the build.
-	Images           []string               `json:"images,omitempty"`          // A list of images to be pushed upon the successful completion of all build; steps.; ; The images are pushed using the builder service account's credentials.; ; The digests of the pushed images will be stored in the `Build` resource's; results field.; ; If any of the images fail to be pushed, the build status is marked; `FAILURE`.
-	LogsBucket       *string                `json:"logsBucket,omitempty"`      // Google Cloud Storage bucket where logs should be written (see; [Bucket Name; Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).; Logs file names will be of the format `${logs_bucket}/log-${build_id}.txt`.
-	LogURL           *string                `json:"logUrl,omitempty"`          // URL to logs for this build in Google Cloud Console.
-	Options          *Options               `json:"options,omitempty"`         // Special options for this build.
-	ProjectID        *string                `json:"projectId,omitempty"`       // ID of the project.
-	QueueTTL         *QueueTTL              `json:"queueTtl,omitempty"`        // TTL in queue for this build. If provided and the build is enqueued longer; than this value, the build will expire and the build status will be; `EXPIRED`.; ; The TTL starts ticking from create_time.
-	Results          *Results               `json:"results,omitempty"`         // Results of the build.
-	Secrets          []Secret               `json:"secrets,omitempty"`         // Secrets to decrypt using Cloud Key Management Service.
-	Source           *Source                `json:"source,omitempty"`          // The location of the source files to build.
-	SourceProvenance *SourceProvenance      `json:"sourceProvenance,omitempty"`// A permanent fixed identifier for source.
-	StartTime        *string                `json:"startTime,omitempty"`       // Time at which execution of the build was started.
-	Status           *Status                `json:"status"`                    // Status of the build.
-	StatusDetail     *string                `json:"statusDetail,omitempty"`    // Customer-readable message about the current status.
-	Steps            []Step                 `json:"steps,omitempty"`           // The operations to be performed on the workspace.
-	Substitutions    map[string]string      `json:"substitutions,omitempty"`   // Substitutions data for `Build` resource.
-	Tags             []string               `json:"tags,omitempty"`            // Tags for annotation of a `Build`. These are not docker tags.
-	Timeout          *BuildEventDataTimeout `json:"timeout,omitempty"`         // Amount of time that this build should be allowed to run, to second; granularity. If this amount of time elapses, work on the build will cease; and the build status will be `TIMEOUT`.
-	Timing           map[string]TimeSpan    `json:"timing,omitempty"`          // Stores timing information for phases of the build. Valid keys; are:; ; * BUILD: time to execute all build steps; * PUSH: time to push all specified images.; * FETCHSOURCE: time to fetch source.; ; If the build does not specify source or images,; these keys will not be included.
+	Artifacts        *Artifacts             `json:"artifacts,omitempty"`        // Artifacts produced by the build that should be uploaded upon; successful completion of all build steps.
+	BuildTriggerID   *string                `json:"buildTriggerId,omitempty"`   // The ID of the `BuildTrigger` that triggered this build, if it; was triggered automatically.
+	CreateTime       *string                `json:"createTime,omitempty"`       // Time at which the request to create the build was received.
+	FinishTime       *string                `json:"finishTime,omitempty"`       // Time at which execution of the build was finished.; ; The difference between finish_time and start_time is the duration of the; build's execution.
+	ID               *string                `json:"id,omitempty"`               // Unique identifier of the build.
+	Images           []string               `json:"images,omitempty"`           // A list of images to be pushed upon the successful completion of all build; steps.; ; The images are pushed using the builder service account's credentials.; ; The digests of the pushed images will be stored in the `Build` resource's; results field.; ; If any of the images fail to be pushed, the build status is marked; `FAILURE`.
+	LogsBucket       *string                `json:"logsBucket,omitempty"`       // Google Cloud Storage bucket where logs should be written (see; [Bucket Name; Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).; Logs file names will be of the format `${logs_bucket}/log-${build_id}.txt`.
+	LogURL           *string                `json:"logUrl,omitempty"`           // URL to logs for this build in Google Cloud Console.
+	Options          *Options               `json:"options,omitempty"`          // Special options for this build.
+	ProjectID        *string                `json:"projectId,omitempty"`        // ID of the project.
+	QueueTTL         *QueueTTL              `json:"queueTtl,omitempty"`         // TTL in queue for this build. If provided and the build is enqueued longer; than this value, the build will expire and the build status will be; `EXPIRED`.; ; The TTL starts ticking from create_time.
+	Results          *Results               `json:"results,omitempty"`          // Results of the build.
+	Secrets          []Secret               `json:"secrets,omitempty"`          // Secrets to decrypt using Cloud Key Management Service.
+	Source           *Source                `json:"source,omitempty"`           // The location of the source files to build.
+	SourceProvenance *SourceProvenance      `json:"sourceProvenance,omitempty"` // A permanent fixed identifier for source.
+	StartTime        *string                `json:"startTime,omitempty"`        // Time at which execution of the build was started.
+	Status           *Status                `json:"status"`                     // Status of the build.
+	StatusDetail     *string                `json:"statusDetail,omitempty"`     // Customer-readable message about the current status.
+	Steps            []Step                 `json:"steps,omitempty"`            // The operations to be performed on the workspace.
+	Substitutions    map[string]string      `json:"substitutions,omitempty"`    // Substitutions data for `Build` resource.
+	Tags             []string               `json:"tags,omitempty"`             // Tags for annotation of a `Build`. These are not docker tags.
+	Timeout          *BuildEventDataTimeout `json:"timeout,omitempty"`          // Amount of time that this build should be allowed to run, to second; granularity. If this amount of time elapses, work on the build will cease; and the build status will be `TIMEOUT`.
+	Timing           map[string]TimeSpan    `json:"timing,omitempty"`           // Stores timing information for phases of the build. Valid keys; are:; ; * BUILD: time to execute all build steps; * PUSH: time to push all specified images.; * FETCHSOURCE: time to fetch source.; ; If the build does not specify source or images,; these keys will not be included.
 }
 
 // Artifacts produced by the build that should be uploaded upon
 // successful completion of all build steps.
 type Artifacts struct {
-	Images  []string `json:"images,omitempty"` // A list of images to be pushed upon the successful completion of all build; steps.; ; The images will be pushed using the builder service account's credentials.; ; The digests of the pushed images will be stored in the Build resource's; results field.; ; If any of the images fail to be pushed, the build is marked FAILURE.
-	Objects *Objects `json:"objects,omitempty"`// A list of objects to be uploaded to Cloud Storage upon successful; completion of all build steps.; ; Files in the workspace matching specified paths globs will be uploaded to; the specified Cloud Storage location using the builder service account's; credentials.; ; The location and generation of the uploaded objects will be stored in the; Build resource's results field.; ; If any objects fail to be pushed, the build is marked FAILURE.
+	Images  []string `json:"images,omitempty"`  // A list of images to be pushed upon the successful completion of all build; steps.; ; The images will be pushed using the builder service account's credentials.; ; The digests of the pushed images will be stored in the Build resource's; results field.; ; If any of the images fail to be pushed, the build is marked FAILURE.
+	Objects *Objects `json:"objects,omitempty"` // A list of objects to be uploaded to Cloud Storage upon successful; completion of all build steps.; ; Files in the workspace matching specified paths globs will be uploaded to; the specified Cloud Storage location using the builder service account's; credentials.; ; The location and generation of the uploaded objects will be stored in the; Build resource's results field.; ; If any objects fail to be pushed, the build is marked FAILURE.
 }
 
 // A list of objects to be uploaded to Cloud Storage upon successful
@@ -61,39 +61,39 @@ type Artifacts struct {
 //
 // If any objects fail to be pushed, the build is marked FAILURE.
 type Objects struct {
-	Location *string        `json:"location,omitempty"`// Cloud Storage bucket and optional object path, in the form; "gs://bucket/path/to/somewhere/". (see [Bucket Name; Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).; ; Files in the workspace matching any path pattern will be uploaded to; Cloud Storage with this location as a prefix.
-	Paths    []string       `json:"paths,omitempty"`   // Path globs used to match files in the build's workspace.
-	Timing   *ObjectsTiming `json:"timing,omitempty"`  // Stores timing information for pushing all artifact objects.
+	Location *string        `json:"location,omitempty"` // Cloud Storage bucket and optional object path, in the form; "gs://bucket/path/to/somewhere/". (see [Bucket Name; Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).; ; Files in the workspace matching any path pattern will be uploaded to; Cloud Storage with this location as a prefix.
+	Paths    []string       `json:"paths,omitempty"`    // Path globs used to match files in the build's workspace.
+	Timing   *ObjectsTiming `json:"timing,omitempty"`   // Stores timing information for pushing all artifact objects.
 }
 
 // Stores timing information for pushing all artifact objects.
 //
 // Start and end times for a build execution phase.
 type ObjectsTiming struct {
-	EndTime   *string `json:"endTime,omitempty"`  // End of time span.
-	StartTime *string `json:"startTime,omitempty"`// Start of time span.
+	EndTime   *string `json:"endTime,omitempty"`   // End of time span.
+	StartTime *string `json:"startTime,omitempty"` // Start of time span.
 }
 
 // Special options for this build.
 type Options struct {
-	DiskSizeGB            *int64                 `json:"diskSizeGb,omitempty"`          // Requested disk size for the VM that runs the build. Note that this is *NOT*; "disk free"; some of the space will be used by the operating system and; build utilities. Also note that this is the minimum disk size that will be; allocated for the build -- the build may run with a larger disk than; requested. At present, the maximum disk size is 1000GB; builds that request; more than the maximum are rejected with an error.
-	Env                   []string               `json:"env,omitempty"`                 // A list of global environment variable definitions that will exist for all; build steps in this build. If a variable is defined in both globally and in; a build step, the variable will use the build step value.; ; The elements are of the form "KEY=VALUE" for the environment variable "KEY"; being given the value "VALUE".
-	Logging               *Logging               `json:"logging"`                       // Option to specify the logging mode, which determines where the logs are; stored.
-	LogStreamingOption    *LogStreamingOption    `json:"logStreamingOption"`            // Option to define build log streaming behavior to Google Cloud; Storage.
-	MachineType           *MachineType           `json:"machineType"`                   // Compute Engine machine type on which to run the build.
-	RequestedVerifyOption *RequestedVerifyOption `json:"requestedVerifyOption"`         // Requested verifiability options.
-	SecretEnv             []string               `json:"secretEnv,omitempty"`           // A list of global environment variables, which are encrypted using a Cloud; Key Management Service crypto key. These values must be specified in the; build's `Secret`. These variables will be available to all build steps; in this build.
-	SourceProvenanceHash  []SourceProvenanceHash `json:"sourceProvenanceHash,omitempty"`// Requested hash for SourceProvenance.
-	SubstitutionOption    *SubstitutionOption    `json:"substitutionOption"`            // Option to specify behavior when there is an error in the substitution; checks.
-	Volumes               []Volume               `json:"volumes,omitempty"`             // Global list of volumes to mount for ALL build steps; ; Each volume is created as an empty volume prior to starting the build; process. Upon completion of the build, volumes and their contents are; discarded. Global volume names and paths cannot conflict with the volumes; defined a build step.; ; Using a global volume in a build with only one step is not valid as; it is indicative of a build request with an incorrect configuration.
-	WorkerPool            *string                `json:"workerPool,omitempty"`          // Option to specify a `WorkerPool` for the build.; Format: projects/{project}/locations/{location}/workerPools/{workerPool}
+	DiskSizeGB            *int64                 `json:"diskSizeGb,string,omitempty"`    // Requested disk size for the VM that runs the build. Note that this is *NOT*; "disk free"; some of the space will be used by the operating system and; build utilities. Also note that this is the minimum disk size that will be; allocated for the build -- the build may run with a larger disk than; requested. At present, the maximum disk size is 1000GB; builds that request; more than the maximum are rejected with an error.
+	Env                   []string               `json:"env,omitempty"`                  // A list of global environment variable definitions that will exist for all; build steps in this build. If a variable is defined in both globally and in; a build step, the variable will use the build step value.; ; The elements are of the form "KEY=VALUE" for the environment variable "KEY"; being given the value "VALUE".
+	Logging               *Logging               `json:"logging"`                        // Option to specify the logging mode, which determines where the logs are; stored.
+	LogStreamingOption    *LogStreamingOption    `json:"logStreamingOption"`             // Option to define build log streaming behavior to Google Cloud; Storage.
+	MachineType           *MachineType           `json:"machineType"`                    // Compute Engine machine type on which to run the build.
+	RequestedVerifyOption *RequestedVerifyOption `json:"requestedVerifyOption"`          // Requested verifiability options.
+	SecretEnv             []string               `json:"secretEnv,omitempty"`            // A list of global environment variables, which are encrypted using a Cloud; Key Management Service crypto key. These values must be specified in the; build's `Secret`. These variables will be available to all build steps; in this build.
+	SourceProvenanceHash  []SourceProvenanceHash `json:"sourceProvenanceHash,omitempty"` // Requested hash for SourceProvenance.
+	SubstitutionOption    *SubstitutionOption    `json:"substitutionOption"`             // Option to specify behavior when there is an error in the substitution; checks.
+	Volumes               []Volume               `json:"volumes,omitempty"`              // Global list of volumes to mount for ALL build steps; ; Each volume is created as an empty volume prior to starting the build; process. Upon completion of the build, volumes and their contents are; discarded. Global volume names and paths cannot conflict with the volumes; defined a build step.; ; Using a global volume in a build with only one step is not valid as; it is indicative of a build request with an incorrect configuration.
+	WorkerPool            *string                `json:"workerPool,omitempty"`           // Option to specify a `WorkerPool` for the build.; Format: projects/{project}/locations/{location}/workerPools/{workerPool}
 }
 
 // Volume describes a Docker container volume which is mounted into build steps
 // in order to persist files across build step execution.
 type Volume struct {
-	Name *string `json:"name,omitempty"`// Name of the volume to mount.; ; Volume names must be unique per build step and must be valid names for; Docker volumes. Each named volume must be used by at least two build steps.
-	Path *string `json:"path,omitempty"`// Path at which to mount the volume.; ; Paths must be absolute and cannot conflict with other volume paths on the; same build step or with certain reserved volume paths.
+	Name *string `json:"name,omitempty"` // Name of the volume to mount.; ; Volume names must be unique per build step and must be valid names for; Docker volumes. Each named volume must be used by at least two build steps.
+	Path *string `json:"path,omitempty"` // Path at which to mount the volume.; ; Paths must be absolute and cannot conflict with other volume paths on the; same build step or with certain reserved volume paths.
 }
 
 // TTL in queue for this build. If provided and the build is enqueued longer
@@ -102,18 +102,18 @@ type Volume struct {
 //
 // The TTL starts ticking from create_time.
 type QueueTTL struct {
-	Nanos   *int64 `json:"nanos,omitempty"`  // Signed fractions of a second at nanosecond resolution of the span; of time. Durations less than one second are represented with a 0; `seconds` field and a positive or negative `nanos` field. For durations; of one second or more, a non-zero value for the `nanos` field must be; of the same sign as the `seconds` field. Must be from -999,999,999; to +999,999,999 inclusive.
-	Seconds *int64 `json:"seconds,omitempty"`// Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+	Nanos   *int64 `json:"nanos,string,omitempty"`   // Signed fractions of a second at nanosecond resolution of the span; of time. Durations less than one second are represented with a 0; `seconds` field and a positive or negative `nanos` field. For durations; of one second or more, a non-zero value for the `nanos` field must be; of the same sign as the `seconds` field. Must be from -999,999,999; to +999,999,999 inclusive.
+	Seconds *int64 `json:"seconds,string,omitempty"` // Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
 }
 
 // Results of the build.
 type Results struct {
-	ArtifactManifest *string         `json:"artifactManifest,omitempty"`// Path to the artifact manifest. Only populated when artifacts are uploaded.
-	ArtifactTiming   *ArtifactTiming `json:"artifactTiming,omitempty"`  // Time to push all non-container artifacts.
-	BuildStepImages  []string        `json:"buildStepImages,omitempty"` // List of build step digests, in the order corresponding to build step; indices.
-	BuildStepOutputs []string        `json:"buildStepOutputs,omitempty"`// List of build step outputs, produced by builder images, in the order; corresponding to build step indices.; ; [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders); can produce this output by writing to `$BUILDER_OUTPUT/output`.; Only the first 4KB of data is stored.
-	Images           []Image         `json:"images,omitempty"`          // Container images that were built as a part of the build.
-	NumArtifacts     *int64          `json:"numArtifacts,omitempty"`    // Number of artifacts uploaded. Only populated when artifacts are uploaded.
+	ArtifactManifest *string         `json:"artifactManifest,omitempty"`    // Path to the artifact manifest. Only populated when artifacts are uploaded.
+	ArtifactTiming   *ArtifactTiming `json:"artifactTiming,omitempty"`      // Time to push all non-container artifacts.
+	BuildStepImages  []string        `json:"buildStepImages,omitempty"`     // List of build step digests, in the order corresponding to build step; indices.
+	BuildStepOutputs []string        `json:"buildStepOutputs,omitempty"`    // List of build step outputs, produced by builder images, in the order; corresponding to build step indices.; ; [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders); can produce this output by writing to `$BUILDER_OUTPUT/output`.; Only the first 4KB of data is stored.
+	Images           []Image         `json:"images,omitempty"`              // Container images that were built as a part of the build.
+	NumArtifacts     *int64          `json:"numArtifacts,string,omitempty"` // Number of artifacts uploaded. Only populated when artifacts are uploaded.
 }
 
 // Time to push all non-container artifacts.
@@ -122,15 +122,15 @@ type Results struct {
 //
 // Start and end times for a build execution phase.
 type ArtifactTiming struct {
-	EndTime   *string `json:"endTime,omitempty"`  // End of time span.
-	StartTime *string `json:"startTime,omitempty"`// Start of time span.
+	EndTime   *string `json:"endTime,omitempty"`   // End of time span.
+	StartTime *string `json:"startTime,omitempty"` // Start of time span.
 }
 
 // An image built by the pipeline.
 type Image struct {
-	Digest     *string     `json:"digest,omitempty"`    // Docker Registry 2.0 digest.
-	Name       *string     `json:"name,omitempty"`      // Name used to push the container image to Google Container Registry, as; presented to `docker push`.
-	PushTiming *PushTiming `json:"pushTiming,omitempty"`// Stores timing information for pushing the specified image.
+	Digest     *string     `json:"digest,omitempty"`     // Docker Registry 2.0 digest.
+	Name       *string     `json:"name,omitempty"`       // Name used to push the container image to Google Container Registry, as; presented to `docker push`.
+	PushTiming *PushTiming `json:"pushTiming,omitempty"` // Stores timing information for pushing the specified image.
 }
 
 // Stores timing information for pushing the specified image.
@@ -139,21 +139,21 @@ type Image struct {
 //
 // Start and end times for a build execution phase.
 type PushTiming struct {
-	EndTime   *string `json:"endTime,omitempty"`  // End of time span.
-	StartTime *string `json:"startTime,omitempty"`// Start of time span.
+	EndTime   *string `json:"endTime,omitempty"`   // End of time span.
+	StartTime *string `json:"startTime,omitempty"` // Start of time span.
 }
 
 // Pairs a set of secret environment variables containing encrypted
 // values with the Cloud KMS key to use to decrypt the value.
 type Secret struct {
-	KmsKeyName *string           `json:"kmsKeyName,omitempty"`// Cloud KMS key name to use to decrypt these envs.
-	SecretEnv  map[string]string `json:"secretEnv,omitempty"` // Map of environment variable name to its encrypted value.; ; Secret environment variables must be unique across all of a build's; secrets, and must be used by at least one build step. Values can be at most; 64 KB in size. There can be at most 100 secret values across all of a; build's secrets.
+	KmsKeyName *string           `json:"kmsKeyName,omitempty"` // Cloud KMS key name to use to decrypt these envs.
+	SecretEnv  map[string]string `json:"secretEnv,omitempty"`  // Map of environment variable name to its encrypted value.; ; Secret environment variables must be unique across all of a build's; secrets, and must be used by at least one build step. Values can be at most; 64 KB in size. There can be at most 100 secret values across all of a; build's secrets.
 }
 
 // The location of the source files to build.
 type Source struct {
-	RepoSource    *RepoSourceClass    `json:"repoSource,omitempty"`   // If provided, get the source from this location in a Cloud Source; Repository.
-	StorageSource *StorageSourceClass `json:"storageSource,omitempty"`// If provided, get the source from this location in Google Cloud Storage.
+	RepoSource    *RepoSourceClass    `json:"repoSource,omitempty"`    // If provided, get the source from this location in a Cloud Source; Repository.
+	StorageSource *StorageSourceClass `json:"storageSource,omitempty"` // If provided, get the source from this location in Google Cloud Storage.
 }
 
 // If provided, get the source from this location in a Cloud Source
@@ -161,40 +161,40 @@ type Source struct {
 //
 // Location of the source in a Google Cloud Source Repository.
 type RepoSourceClass struct {
-	BranchName    *string           `json:"branchName,omitempty"`   // Regex matching branches to build.; ; The syntax of the regular expressions accepted is the syntax accepted by; RE2 and described at https://github.com/google/re2/wiki/Syntax
-	CommitSHA     *string           `json:"commitSha,omitempty"`    // Explicit commit SHA to build.
-	Dir           *string           `json:"dir,omitempty"`          // Directory, relative to the source root, in which to run the build.; ; This must be a relative path. If a step's `dir` is specified and is an; absolute path, this value is ignored for that step's execution.
-	InvertRegex   *bool             `json:"invertRegex,omitempty"`  // Only trigger a build if the revision regex does NOT match the revision; regex.
-	ProjectID     *string           `json:"projectId,omitempty"`    // ID of the project that owns the Cloud Source Repository.
-	RepoName      *string           `json:"repoName,omitempty"`     // Name of the Cloud Source Repository.
-	Substitutions map[string]string `json:"substitutions,omitempty"`// Substitutions to use in a triggered build.; Should only be used with RunBuildTrigger
-	TagName       *string           `json:"tagName,omitempty"`      // Regex matching tags to build.; ; The syntax of the regular expressions accepted is the syntax accepted by; RE2 and described at https://github.com/google/re2/wiki/Syntax
+	BranchName    *string           `json:"branchName,omitempty"`    // Regex matching branches to build.; ; The syntax of the regular expressions accepted is the syntax accepted by; RE2 and described at https://github.com/google/re2/wiki/Syntax
+	CommitSHA     *string           `json:"commitSha,omitempty"`     // Explicit commit SHA to build.
+	Dir           *string           `json:"dir,omitempty"`           // Directory, relative to the source root, in which to run the build.; ; This must be a relative path. If a step's `dir` is specified and is an; absolute path, this value is ignored for that step's execution.
+	InvertRegex   *bool             `json:"invertRegex,omitempty"`   // Only trigger a build if the revision regex does NOT match the revision; regex.
+	ProjectID     *string           `json:"projectId,omitempty"`     // ID of the project that owns the Cloud Source Repository.
+	RepoName      *string           `json:"repoName,omitempty"`      // Name of the Cloud Source Repository.
+	Substitutions map[string]string `json:"substitutions,omitempty"` // Substitutions to use in a triggered build.; Should only be used with RunBuildTrigger
+	TagName       *string           `json:"tagName,omitempty"`       // Regex matching tags to build.; ; The syntax of the regular expressions accepted is the syntax accepted by; RE2 and described at https://github.com/google/re2/wiki/Syntax
 }
 
 // If provided, get the source from this location in Google Cloud Storage.
 //
 // Location of the source in an archive file in Google Cloud Storage.
 type StorageSourceClass struct {
-	Bucket     *string `json:"bucket,omitempty"`    // Google Cloud Storage bucket containing the source (see; [Bucket Name; Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
-	Generation *int64  `json:"generation,omitempty"`// Google Cloud Storage generation for the object. If the generation is; omitted, the latest generation will be used.
-	Object     *string `json:"object,omitempty"`    // Google Cloud Storage object containing the source.
+	Bucket     *string `json:"bucket,omitempty"`            // Google Cloud Storage bucket containing the source (see; [Bucket Name; Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
+	Generation *int64  `json:"generation,string,omitempty"` // Google Cloud Storage generation for the object. If the generation is; omitted, the latest generation will be used.
+	Object     *string `json:"object,omitempty"`            // Google Cloud Storage object containing the source.
 }
 
 // A permanent fixed identifier for source.
 type SourceProvenance struct {
-	FileHashes            map[string]FileHashValue    `json:"fileHashes,omitempty"`           // Hash(es) of the build source, which can be used to verify that; the original source integrity was maintained in the build. Note that; `FileHashes` will only be populated if `BuildOptions` has requested a; `SourceProvenanceHash`.; ; The keys to this map are file paths used as build source and the values; contain the hash values for those files.; ; If the build source came in a single package such as a gzipped tarfile; (`.tar.gz`), the `FileHash` will be for the single path to that file.
-	ResolvedRepoSource    *ResolvedRepoSourceClass    `json:"resolvedRepoSource,omitempty"`   // A copy of the build's `source.repo_source`, if exists, with any; revisions resolved.
-	ResolvedStorageSource *ResolvedStorageSourceClass `json:"resolvedStorageSource,omitempty"`// A copy of the build's `source.storage_source`, if exists, with any; generations resolved.
+	FileHashes            map[string]FileHashValue    `json:"fileHashes,omitempty"`            // Hash(es) of the build source, which can be used to verify that; the original source integrity was maintained in the build. Note that; `FileHashes` will only be populated if `BuildOptions` has requested a; `SourceProvenanceHash`.; ; The keys to this map are file paths used as build source and the values; contain the hash values for those files.; ; If the build source came in a single package such as a gzipped tarfile; (`.tar.gz`), the `FileHash` will be for the single path to that file.
+	ResolvedRepoSource    *ResolvedRepoSourceClass    `json:"resolvedRepoSource,omitempty"`    // A copy of the build's `source.repo_source`, if exists, with any; revisions resolved.
+	ResolvedStorageSource *ResolvedStorageSourceClass `json:"resolvedStorageSource,omitempty"` // A copy of the build's `source.storage_source`, if exists, with any; generations resolved.
 }
 
 type FileHashValue struct {
-	FileHash []FileHashElement `json:"fileHash,omitempty"`// Collection of file hashes.
+	FileHash []FileHashElement `json:"fileHash,omitempty"` // Collection of file hashes.
 }
 
 // Container message for hash values.
 type FileHashElement struct {
-	Type  *Type   `json:"type"`           // The type of hash that was performed.
-	Value *string `json:"value,omitempty"`// The hash value.
+	Type  *Type   `json:"type"`            // The type of hash that was performed.
+	Value *string `json:"value,omitempty"` // The hash value.
 }
 
 // A copy of the build's `source.repo_source`, if exists, with any
@@ -205,14 +205,14 @@ type FileHashElement struct {
 //
 // Location of the source in a Google Cloud Source Repository.
 type ResolvedRepoSourceClass struct {
-	BranchName    *string           `json:"branchName,omitempty"`   // Regex matching branches to build.; ; The syntax of the regular expressions accepted is the syntax accepted by; RE2 and described at https://github.com/google/re2/wiki/Syntax
-	CommitSHA     *string           `json:"commitSha,omitempty"`    // Explicit commit SHA to build.
-	Dir           *string           `json:"dir,omitempty"`          // Directory, relative to the source root, in which to run the build.; ; This must be a relative path. If a step's `dir` is specified and is an; absolute path, this value is ignored for that step's execution.
-	InvertRegex   *bool             `json:"invertRegex,omitempty"`  // Only trigger a build if the revision regex does NOT match the revision; regex.
-	ProjectID     *string           `json:"projectId,omitempty"`    // ID of the project that owns the Cloud Source Repository.
-	RepoName      *string           `json:"repoName,omitempty"`     // Name of the Cloud Source Repository.
-	Substitutions map[string]string `json:"substitutions,omitempty"`// Substitutions to use in a triggered build.; Should only be used with RunBuildTrigger
-	TagName       *string           `json:"tagName,omitempty"`      // Regex matching tags to build.; ; The syntax of the regular expressions accepted is the syntax accepted by; RE2 and described at https://github.com/google/re2/wiki/Syntax
+	BranchName    *string           `json:"branchName,omitempty"`    // Regex matching branches to build.; ; The syntax of the regular expressions accepted is the syntax accepted by; RE2 and described at https://github.com/google/re2/wiki/Syntax
+	CommitSHA     *string           `json:"commitSha,omitempty"`     // Explicit commit SHA to build.
+	Dir           *string           `json:"dir,omitempty"`           // Directory, relative to the source root, in which to run the build.; ; This must be a relative path. If a step's `dir` is specified and is an; absolute path, this value is ignored for that step's execution.
+	InvertRegex   *bool             `json:"invertRegex,omitempty"`   // Only trigger a build if the revision regex does NOT match the revision; regex.
+	ProjectID     *string           `json:"projectId,omitempty"`     // ID of the project that owns the Cloud Source Repository.
+	RepoName      *string           `json:"repoName,omitempty"`      // Name of the Cloud Source Repository.
+	Substitutions map[string]string `json:"substitutions,omitempty"` // Substitutions to use in a triggered build.; Should only be used with RunBuildTrigger
+	TagName       *string           `json:"tagName,omitempty"`       // Regex matching tags to build.; ; The syntax of the regular expressions accepted is the syntax accepted by; RE2 and described at https://github.com/google/re2/wiki/Syntax
 }
 
 // A copy of the build's `source.storage_source`, if exists, with any
@@ -222,26 +222,26 @@ type ResolvedRepoSourceClass struct {
 //
 // Location of the source in an archive file in Google Cloud Storage.
 type ResolvedStorageSourceClass struct {
-	Bucket     *string `json:"bucket,omitempty"`    // Google Cloud Storage bucket containing the source (see; [Bucket Name; Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
-	Generation *int64  `json:"generation,omitempty"`// Google Cloud Storage generation for the object. If the generation is; omitted, the latest generation will be used.
-	Object     *string `json:"object,omitempty"`    // Google Cloud Storage object containing the source.
+	Bucket     *string `json:"bucket,omitempty"`            // Google Cloud Storage bucket containing the source (see; [Bucket Name; Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
+	Generation *int64  `json:"generation,string,omitempty"` // Google Cloud Storage generation for the object. If the generation is; omitted, the latest generation will be used.
+	Object     *string `json:"object,omitempty"`            // Google Cloud Storage object containing the source.
 }
 
 // A step in the build pipeline.
 type Step struct {
-	Args       []string     `json:"args,omitempty"`      // A list of arguments that will be presented to the step when it is started.; ; If the image used to run the step's container has an entrypoint, the `args`; are used as arguments to that entrypoint. If the image does not define; an entrypoint, the first element in args is used as the entrypoint,; and the remainder will be used as arguments.
-	Dir        *string      `json:"dir,omitempty"`       // Working directory to use when running this step's container.; ; If this value is a relative path, it is relative to the build's working; directory. If this value is absolute, it may be outside the build's working; directory, in which case the contents of the path may not be persisted; across build step executions, unless a `volume` for that path is specified.; ; If the build specifies a `RepoSource` with `dir` and a step with a `dir`,; which specifies an absolute path, the `RepoSource` `dir` is ignored for; the step's execution.
-	Entrypoint *string      `json:"entrypoint,omitempty"`// Entrypoint to be used instead of the build step image's default entrypoint.; If unset, the image's default entrypoint is used.
-	Env        []string     `json:"env,omitempty"`       // A list of environment variable definitions to be used when running a step.; ; The elements are of the form "KEY=VALUE" for the environment variable "KEY"; being given the value "VALUE".
-	ID         *string      `json:"id,omitempty"`        // Unique identifier for this build step, used in `wait_for` to; reference this build step as a dependency.
-	Name       *string      `json:"name,omitempty"`      // The name of the container image that will run this particular; build step.; ; If the image is available in the host's Docker daemon's cache, it; will be run directly. If not, the host will attempt to pull the image; first, using the builder service account's credentials if necessary.; ; The Docker daemon's cache will already have the latest versions of all of; the officially supported build steps; ; ([https://github.com/GoogleCloudPlatform/cloud-builders](https://github.com/GoogleCloudPlatform/cloud-builders)).; The Docker daemon will also have cached many of the layers for some popular; images, like "ubuntu", "debian", but they will be refreshed at the time you; attempt to use them.; ; If you built an image in a previous build step, it will be stored in the; host's Docker daemon's cache and is available to use as the name for a; later build step.
-	PullTiming *PullTiming  `json:"pullTiming,omitempty"`// Stores timing information for pulling this build step's; builder image only.
-	SecretEnv  []string     `json:"secretEnv,omitempty"` // A list of environment variables which are encrypted using a Cloud Key; Management Service crypto key. These values must be specified in the; build's `Secret`.
-	Status     *Status      `json:"status"`              // Status of the build step. At this time, build step status is; only updated on build completion; step status is not updated in real-time; as the build progresses.
-	Timeout    *StepTimeout `json:"timeout,omitempty"`   // Time limit for executing this build step. If not defined, the step has no; time limit and will be allowed to continue to run until either it completes; or the build itself times out.
-	Timing     *StepTiming  `json:"timing,omitempty"`    // Stores timing information for executing this build step.
-	Volumes    []Volume     `json:"volumes,omitempty"`   // List of volumes to mount into the build step.; ; Each volume is created as an empty volume prior to execution of the; build step. Upon completion of the build, volumes and their contents are; discarded.; ; Using a named volume in only one step is not valid as it is indicative; of a build request with an incorrect configuration.
-	WaitFor    []string     `json:"waitFor,omitempty"`   // The ID(s) of the step(s) that this build step depends on.; This build step will not start until all the build steps in `wait_for`; have completed successfully. If `wait_for` is empty, this build step will; start when all previous build steps in the `Build.Steps` list have; completed successfully.
+	Args       []string     `json:"args,omitempty"`       // A list of arguments that will be presented to the step when it is started.; ; If the image used to run the step's container has an entrypoint, the `args`; are used as arguments to that entrypoint. If the image does not define; an entrypoint, the first element in args is used as the entrypoint,; and the remainder will be used as arguments.
+	Dir        *string      `json:"dir,omitempty"`        // Working directory to use when running this step's container.; ; If this value is a relative path, it is relative to the build's working; directory. If this value is absolute, it may be outside the build's working; directory, in which case the contents of the path may not be persisted; across build step executions, unless a `volume` for that path is specified.; ; If the build specifies a `RepoSource` with `dir` and a step with a `dir`,; which specifies an absolute path, the `RepoSource` `dir` is ignored for; the step's execution.
+	Entrypoint *string      `json:"entrypoint,omitempty"` // Entrypoint to be used instead of the build step image's default entrypoint.; If unset, the image's default entrypoint is used.
+	Env        []string     `json:"env,omitempty"`        // A list of environment variable definitions to be used when running a step.; ; The elements are of the form "KEY=VALUE" for the environment variable "KEY"; being given the value "VALUE".
+	ID         *string      `json:"id,omitempty"`         // Unique identifier for this build step, used in `wait_for` to; reference this build step as a dependency.
+	Name       *string      `json:"name,omitempty"`       // The name of the container image that will run this particular; build step.; ; If the image is available in the host's Docker daemon's cache, it; will be run directly. If not, the host will attempt to pull the image; first, using the builder service account's credentials if necessary.; ; The Docker daemon's cache will already have the latest versions of all of; the officially supported build steps; ; ([https://github.com/GoogleCloudPlatform/cloud-builders](https://github.com/GoogleCloudPlatform/cloud-builders)).; The Docker daemon will also have cached many of the layers for some popular; images, like "ubuntu", "debian", but they will be refreshed at the time you; attempt to use them.; ; If you built an image in a previous build step, it will be stored in the; host's Docker daemon's cache and is available to use as the name for a; later build step.
+	PullTiming *PullTiming  `json:"pullTiming,omitempty"` // Stores timing information for pulling this build step's; builder image only.
+	SecretEnv  []string     `json:"secretEnv,omitempty"`  // A list of environment variables which are encrypted using a Cloud Key; Management Service crypto key. These values must be specified in the; build's `Secret`.
+	Status     *Status      `json:"status"`               // Status of the build step. At this time, build step status is; only updated on build completion; step status is not updated in real-time; as the build progresses.
+	Timeout    *StepTimeout `json:"timeout,omitempty"`    // Time limit for executing this build step. If not defined, the step has no; time limit and will be allowed to continue to run until either it completes; or the build itself times out.
+	Timing     *StepTiming  `json:"timing,omitempty"`     // Stores timing information for executing this build step.
+	Volumes    []Volume     `json:"volumes,omitempty"`    // List of volumes to mount into the build step.; ; Each volume is created as an empty volume prior to execution of the; build step. Upon completion of the build, volumes and their contents are; discarded.; ; Using a named volume in only one step is not valid as it is indicative; of a build request with an incorrect configuration.
+	WaitFor    []string     `json:"waitFor,omitempty"`    // The ID(s) of the step(s) that this build step depends on.; This build step will not start until all the build steps in `wait_for`; have completed successfully. If `wait_for` is empty, this build step will; start when all previous build steps in the `Build.Steps` list have; completed successfully.
 }
 
 // Stores timing information for pulling this build step's
@@ -251,16 +251,16 @@ type Step struct {
 //
 // Start and end times for a build execution phase.
 type PullTiming struct {
-	EndTime   *string `json:"endTime,omitempty"`  // End of time span.
-	StartTime *string `json:"startTime,omitempty"`// Start of time span.
+	EndTime   *string `json:"endTime,omitempty"`   // End of time span.
+	StartTime *string `json:"startTime,omitempty"` // Start of time span.
 }
 
 // Time limit for executing this build step. If not defined, the step has no
 // time limit and will be allowed to continue to run until either it completes
 // or the build itself times out.
 type StepTimeout struct {
-	Nanos   *int64 `json:"nanos,omitempty"`  // Signed fractions of a second at nanosecond resolution of the span; of time. Durations less than one second are represented with a 0; `seconds` field and a positive or negative `nanos` field. For durations; of one second or more, a non-zero value for the `nanos` field must be; of the same sign as the `seconds` field. Must be from -999,999,999; to +999,999,999 inclusive.
-	Seconds *int64 `json:"seconds,omitempty"`// Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+	Nanos   *int64 `json:"nanos,string,omitempty"`   // Signed fractions of a second at nanosecond resolution of the span; of time. Durations less than one second are represented with a 0; `seconds` field and a positive or negative `nanos` field. For durations; of one second or more, a non-zero value for the `nanos` field must be; of the same sign as the `seconds` field. Must be from -999,999,999; to +999,999,999 inclusive.
+	Seconds *int64 `json:"seconds,string,omitempty"` // Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
 }
 
 // Stores timing information for executing this build step.
@@ -269,77 +269,84 @@ type StepTimeout struct {
 //
 // Start and end times for a build execution phase.
 type StepTiming struct {
-	EndTime   *string `json:"endTime,omitempty"`  // End of time span.
-	StartTime *string `json:"startTime,omitempty"`// Start of time span.
+	EndTime   *string `json:"endTime,omitempty"`   // End of time span.
+	StartTime *string `json:"startTime,omitempty"` // Start of time span.
 }
 
 // Amount of time that this build should be allowed to run, to second
 // granularity. If this amount of time elapses, work on the build will cease
 // and the build status will be `TIMEOUT`.
 type BuildEventDataTimeout struct {
-	Nanos   *int64 `json:"nanos,omitempty"`  // Signed fractions of a second at nanosecond resolution of the span; of time. Durations less than one second are represented with a 0; `seconds` field and a positive or negative `nanos` field. For durations; of one second or more, a non-zero value for the `nanos` field must be; of the same sign as the `seconds` field. Must be from -999,999,999; to +999,999,999 inclusive.
-	Seconds *int64 `json:"seconds,omitempty"`// Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+	Nanos   *int64 `json:"nanos,string,omitempty"`   // Signed fractions of a second at nanosecond resolution of the span; of time. Durations less than one second are represented with a 0; `seconds` field and a positive or negative `nanos` field. For durations; of one second or more, a non-zero value for the `nanos` field must be; of the same sign as the `seconds` field. Must be from -999,999,999; to +999,999,999 inclusive.
+	Seconds *int64 `json:"seconds,string,omitempty"` // Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
 }
 
 // Stores timing information for pushing all artifact objects.
 //
 // Start and end times for a build execution phase.
 type TimeSpan struct {
-	EndTime   *string `json:"endTime,omitempty"`  // End of time span.
-	StartTime *string `json:"startTime,omitempty"`// Start of time span.
+	EndTime   *string `json:"endTime,omitempty"`   // End of time span.
+	StartTime *string `json:"startTime,omitempty"` // Start of time span.
 }
 
 type LogStreamingOptionEnum string
+
 const (
 	StreamDefault LogStreamingOptionEnum = "STREAM_DEFAULT"
-	StreamOff LogStreamingOptionEnum = "STREAM_OFF"
-	StreamOn LogStreamingOptionEnum = "STREAM_ON"
+	StreamOff     LogStreamingOptionEnum = "STREAM_OFF"
+	StreamOn      LogStreamingOptionEnum = "STREAM_ON"
 )
 
 type LoggingEnum string
+
 const (
-	GcsOnly LoggingEnum = "GCS_ONLY"
-	Legacy LoggingEnum = "LEGACY"
+	GcsOnly            LoggingEnum = "GCS_ONLY"
+	Legacy             LoggingEnum = "LEGACY"
 	LoggingUnspecified LoggingEnum = "LOGGING_UNSPECIFIED"
 )
 
 type MachineTypeEnum string
+
 const (
 	N1Highcpu32 MachineTypeEnum = "N1_HIGHCPU_32"
-	N1Highcpu8 MachineTypeEnum = "N1_HIGHCPU_8"
+	N1Highcpu8  MachineTypeEnum = "N1_HIGHCPU_8"
 	Unspecified MachineTypeEnum = "UNSPECIFIED"
 )
 
 type RequestedVerifyOptionEnum string
+
 const (
 	NotVerified RequestedVerifyOptionEnum = "NOT_VERIFIED"
-	Verified RequestedVerifyOptionEnum = "VERIFIED"
+	Verified    RequestedVerifyOptionEnum = "VERIFIED"
 )
 
 type SourceProvenanceHashEnum string
+
 const (
-	Md5 SourceProvenanceHashEnum = "MD5"
-	None SourceProvenanceHashEnum = "NONE"
+	Md5    SourceProvenanceHashEnum = "MD5"
+	None   SourceProvenanceHashEnum = "NONE"
 	Sha256 SourceProvenanceHashEnum = "SHA256"
 )
 
 type SubstitutionOptionEnum string
+
 const (
 	AllowLoose SubstitutionOptionEnum = "ALLOW_LOOSE"
-	MustMatch SubstitutionOptionEnum = "MUST_MATCH"
+	MustMatch  SubstitutionOptionEnum = "MUST_MATCH"
 )
 
 type StatusEnum string
+
 const (
-	Cancelled StatusEnum = "CANCELLED"
-	Expired StatusEnum = "EXPIRED"
-	Failure StatusEnum = "FAILURE"
+	Cancelled     StatusEnum = "CANCELLED"
+	Expired       StatusEnum = "EXPIRED"
+	Failure       StatusEnum = "FAILURE"
 	InternalError StatusEnum = "INTERNAL_ERROR"
-	Queued StatusEnum = "QUEUED"
+	Queued        StatusEnum = "QUEUED"
 	StatusUnknown StatusEnum = "STATUS_UNKNOWN"
-	Success StatusEnum = "SUCCESS"
-	Timeout StatusEnum = "TIMEOUT"
-	Working StatusEnum = "WORKING"
+	Success       StatusEnum = "SUCCESS"
+	Timeout       StatusEnum = "TIMEOUT"
+	Working       StatusEnum = "WORKING"
 )
 
 // Option to define build log streaming behavior to Google Cloud

--- a/cloud/firestore/v1/document_event_data.go
+++ b/cloud/firestore/v1/document_event_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ import "encoding/json"
 
 // The data within all Firestore document events.
 type DocumentEventData struct {
-	OldValue   *OldValue   `json:"oldValue,omitempty"`  // A Document object containing a pre-operation document snapshot.; This is only populated for update and delete events.
-	UpdateMask *UpdateMask `json:"updateMask,omitempty"`// A DocumentMask object that lists changed fields.; This is only populated for update events.
-	Value      *Value      `json:"value,omitempty"`     // A Document object containing a post-operation document snapshot.; This is not populated for delete events. (TODO: check this!)
+	OldValue   *OldValue   `json:"oldValue,omitempty"`   // A Document object containing a pre-operation document snapshot.; This is only populated for update and delete events.
+	UpdateMask *UpdateMask `json:"updateMask,omitempty"` // A DocumentMask object that lists changed fields.; This is only populated for update events.
+	Value      *Value      `json:"value,omitempty"`      // A Document object containing a post-operation document snapshot.; This is not populated for delete events. (TODO: check this!)
 }
 
 // A Document object containing a pre-operation document snapshot.
@@ -27,60 +27,60 @@ type DocumentEventData struct {
 //
 // A Firestore document.
 type OldValue struct {
-	CreateTime *string                  `json:"createTime,omitempty"`// The time at which the document was created.; ; This value increases monotonically when a document is deleted then; recreated. It can also be compared to values from other documents and; the `read_time` of a query.
-	Fields     map[string]OldValueField `json:"fields,omitempty"`    // The document's fields.; ; The map keys represent field names.; ; A simple field name contains only characters `a` to `z`, `A` to `Z`,; `0` to `9`, or `_`, and must not start with `0` to `9`. For example,; `foo_bar_17`.; ; Field names matching the regular expression `__.*__` are reserved. Reserved; field names are forbidden except in certain documented contexts. The map; keys, represented as UTF-8, must not exceed 1,500 bytes and cannot be; empty.; ; Field paths may be used in other contexts to refer to structured fields; defined here. For `map_value`, the field path is represented by the simple; or quoted field names of the containing fields, delimited by `.`. For; example, the structured field; `"foo" : { map_value: { "x&y" : { string_value: "hello" }}}` would be; represented by the field path `foo.x&y`.; ; Within a field path, a quoted field name starts and ends with `` ` `` and; may contain any character. Some characters, including `` ` ``, must be; escaped using a `\`. For example, `` `x&y` `` represents `x&y` and; `` `bak\`tik` `` represents `` bak`tik ``.
-	Name       *string                  `json:"name,omitempty"`      // The resource name of the document, for example; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-	UpdateTime *string                  `json:"updateTime,omitempty"`// The time at which the document was last changed.; ; This value is initially set to the `create_time` then increases; monotonically with each change to the document. It can also be; compared to values from other documents and the `read_time` of a query.
+	CreateTime *string                  `json:"createTime,omitempty"` // The time at which the document was created.; ; This value increases monotonically when a document is deleted then; recreated. It can also be compared to values from other documents and; the `read_time` of a query.
+	Fields     map[string]OldValueField `json:"fields,omitempty"`     // The document's fields.; ; The map keys represent field names.; ; A simple field name contains only characters `a` to `z`, `A` to `Z`,; `0` to `9`, or `_`, and must not start with `0` to `9`. For example,; `foo_bar_17`.; ; Field names matching the regular expression `__.*__` are reserved. Reserved; field names are forbidden except in certain documented contexts. The map; keys, represented as UTF-8, must not exceed 1,500 bytes and cannot be; empty.; ; Field paths may be used in other contexts to refer to structured fields; defined here. For `map_value`, the field path is represented by the simple; or quoted field names of the containing fields, delimited by `.`. For; example, the structured field; `"foo" : { map_value: { "x&y" : { string_value: "hello" }}}` would be; represented by the field path `foo.x&y`.; ; Within a field path, a quoted field name starts and ends with `` ` `` and; may contain any character. Some characters, including `` ` ``, must be; escaped using a `\`. For example, `` `x&y` `` represents `x&y` and; `` `bak\`tik` `` represents `` bak`tik ``.
+	Name       *string                  `json:"name,omitempty"`       // The resource name of the document, for example; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+	UpdateTime *string                  `json:"updateTime,omitempty"` // The time at which the document was last changed.; ; This value is initially set to the `create_time` then increases; monotonically with each change to the document. It can also be; compared to values from other documents and the `read_time` of a query.
 }
 
 // A message that can hold any of the supported value types.
 type OldValueField struct {
-	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`    // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
-	BooleanValue   *bool           `json:"booleanValue,omitempty"`  // A boolean value.
-	BytesValue     *string         `json:"bytesValue,omitempty"`    // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
-	DoubleValue    *float64        `json:"doubleValue,omitempty"`   // A double value.
-	GeoPointValue  *GeoPointValue  `json:"geoPointValue,omitempty"` // A geo point value representing a point on the surface of Earth.
-	IntegerValue   *int64          `json:"integerValue,omitempty"`  // An integer value.
-	MapValue       *MapValue       `json:"mapValue,omitempty"`      // A map value.
-	NullValue      *NullValueUnion `json:"nullValue"`               // A null value.
-	ReferenceValue *string         `json:"referenceValue,omitempty"`// A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-	StringValue    *string         `json:"stringValue,omitempty"`   // A string value.; ; The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes of the UTF-8 representation are considered by; queries.
-	TimestampValue *string         `json:"timestampValue,omitempty"`// A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
+	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
+	BooleanValue   *bool           `json:"booleanValue,omitempty"`        // A boolean value.
+	BytesValue     *string         `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
+	DoubleValue    *float64        `json:"doubleValue,omitempty"`         // A double value.
+	GeoPointValue  *GeoPointValue  `json:"geoPointValue,omitempty"`       // A geo point value representing a point on the surface of Earth.
+	IntegerValue   *int64          `json:"integerValue,string,omitempty"` // An integer value.
+	MapValue       *MapValue       `json:"mapValue,omitempty"`            // A map value.
+	NullValue      *NullValueUnion `json:"nullValue"`                     // A null value.
+	ReferenceValue *string         `json:"referenceValue,omitempty"`      // A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+	StringValue    *string         `json:"stringValue,omitempty"`         // A string value.; ; The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes of the UTF-8 representation are considered by; queries.
+	TimestampValue *string         `json:"timestampValue,omitempty"`      // A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
 }
 
 // A message that can hold any of the supported value types.
 type MapValueField struct {
-	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`    // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
-	BooleanValue   *bool           `json:"booleanValue,omitempty"`  // A boolean value.
-	BytesValue     *string         `json:"bytesValue,omitempty"`    // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
-	DoubleValue    *float64        `json:"doubleValue,omitempty"`   // A double value.
-	GeoPointValue  *GeoPointValue  `json:"geoPointValue,omitempty"` // A geo point value representing a point on the surface of Earth.
-	IntegerValue   *int64          `json:"integerValue,omitempty"`  // An integer value.
-	MapValue       *MapValue       `json:"mapValue,omitempty"`      // A map value.
-	NullValue      *NullValueUnion `json:"nullValue"`               // A null value.
-	ReferenceValue *string         `json:"referenceValue,omitempty"`// A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-	StringValue    *string         `json:"stringValue,omitempty"`   // A string value.; ; The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes of the UTF-8 representation are considered by; queries.
-	TimestampValue *string         `json:"timestampValue,omitempty"`// A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
+	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
+	BooleanValue   *bool           `json:"booleanValue,omitempty"`        // A boolean value.
+	BytesValue     *string         `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
+	DoubleValue    *float64        `json:"doubleValue,omitempty"`         // A double value.
+	GeoPointValue  *GeoPointValue  `json:"geoPointValue,omitempty"`       // A geo point value representing a point on the surface of Earth.
+	IntegerValue   *int64          `json:"integerValue,string,omitempty"` // An integer value.
+	MapValue       *MapValue       `json:"mapValue,omitempty"`            // A map value.
+	NullValue      *NullValueUnion `json:"nullValue"`                     // A null value.
+	ReferenceValue *string         `json:"referenceValue,omitempty"`      // A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+	StringValue    *string         `json:"stringValue,omitempty"`         // A string value.; ; The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes of the UTF-8 representation are considered by; queries.
+	TimestampValue *string         `json:"timestampValue,omitempty"`      // A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
 }
 
 // A map value.
 type MapValue struct {
-	Fields map[string]MapValueField `json:"fields,omitempty"`// The map's fields.; ; The map keys represent field names. Field names matching the regular; expression `__.*__` are reserved. Reserved field names are forbidden except; in certain documented contexts. The map keys, represented as UTF-8, must; not exceed 1,500 bytes and cannot be empty.
+	Fields map[string]MapValueField `json:"fields,omitempty"` // The map's fields.; ; The map keys represent field names. Field names matching the regular; expression `__.*__` are reserved. Reserved field names are forbidden except; in certain documented contexts. The map keys, represented as UTF-8, must; not exceed 1,500 bytes and cannot be empty.
 }
 
 // A message that can hold any of the supported value types.
 type ValueElement struct {
-	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`    // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
-	BooleanValue   *bool           `json:"booleanValue,omitempty"`  // A boolean value.
-	BytesValue     *string         `json:"bytesValue,omitempty"`    // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
-	DoubleValue    *float64        `json:"doubleValue,omitempty"`   // A double value.
-	GeoPointValue  *GeoPointValue  `json:"geoPointValue,omitempty"` // A geo point value representing a point on the surface of Earth.
-	IntegerValue   *int64          `json:"integerValue,omitempty"`  // An integer value.
-	MapValue       *MapValue       `json:"mapValue,omitempty"`      // A map value.
-	NullValue      *NullValueUnion `json:"nullValue"`               // A null value.
-	ReferenceValue *string         `json:"referenceValue,omitempty"`// A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-	StringValue    *string         `json:"stringValue,omitempty"`   // A string value.; ; The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes of the UTF-8 representation are considered by; queries.
-	TimestampValue *string         `json:"timestampValue,omitempty"`// A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
+	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
+	BooleanValue   *bool           `json:"booleanValue,omitempty"`        // A boolean value.
+	BytesValue     *string         `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
+	DoubleValue    *float64        `json:"doubleValue,omitempty"`         // A double value.
+	GeoPointValue  *GeoPointValue  `json:"geoPointValue,omitempty"`       // A geo point value representing a point on the surface of Earth.
+	IntegerValue   *int64          `json:"integerValue,string,omitempty"` // An integer value.
+	MapValue       *MapValue       `json:"mapValue,omitempty"`            // A map value.
+	NullValue      *NullValueUnion `json:"nullValue"`                     // A null value.
+	ReferenceValue *string         `json:"referenceValue,omitempty"`      // A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+	StringValue    *string         `json:"stringValue,omitempty"`         // A string value.; ; The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes of the UTF-8 representation are considered by; queries.
+	TimestampValue *string         `json:"timestampValue,omitempty"`      // A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
 }
 
 // An array value.
@@ -88,19 +88,19 @@ type ValueElement struct {
 // Cannot directly contain another array value, though can contain an
 // map which contains another array.
 type ArrayValue struct {
-	Values []ValueElement `json:"values,omitempty"`// Values in the array.
+	Values []ValueElement `json:"values,omitempty"` // Values in the array.
 }
 
 // A geo point value representing a point on the surface of Earth.
 type GeoPointValue struct {
-	Latitude  *float64 `json:"latitude,omitempty"` // The latitude in degrees. It must be in the range [-90.0, +90.0].
-	Longitude *float64 `json:"longitude,omitempty"`// The longitude in degrees. It must be in the range [-180.0, +180.0].
+	Latitude  *float64 `json:"latitude,omitempty"`  // The latitude in degrees. It must be in the range [-90.0, +90.0].
+	Longitude *float64 `json:"longitude,omitempty"` // The longitude in degrees. It must be in the range [-180.0, +180.0].
 }
 
 // A DocumentMask object that lists changed fields.
 // This is only populated for update events.
 type UpdateMask struct {
-	FieldPaths []string `json:"fieldPaths,omitempty"`// The list of field paths in the mask.; See [Document.fields][google.cloud.firestore.v1.events.Document.fields]; for a field path syntax reference.
+	FieldPaths []string `json:"fieldPaths,omitempty"` // The list of field paths in the mask.; See [Document.fields][google.cloud.firestore.v1.events.Document.fields]; for a field path syntax reference.
 }
 
 // A Document object containing a post-operation document snapshot.
@@ -111,13 +111,14 @@ type UpdateMask struct {
 //
 // A Firestore document.
 type Value struct {
-	CreateTime *string                  `json:"createTime,omitempty"`// The time at which the document was created.; ; This value increases monotonically when a document is deleted then; recreated. It can also be compared to values from other documents and; the `read_time` of a query.
-	Fields     map[string]OldValueField `json:"fields,omitempty"`    // The document's fields.; ; The map keys represent field names.; ; A simple field name contains only characters `a` to `z`, `A` to `Z`,; `0` to `9`, or `_`, and must not start with `0` to `9`. For example,; `foo_bar_17`.; ; Field names matching the regular expression `__.*__` are reserved. Reserved; field names are forbidden except in certain documented contexts. The map; keys, represented as UTF-8, must not exceed 1,500 bytes and cannot be; empty.; ; Field paths may be used in other contexts to refer to structured fields; defined here. For `map_value`, the field path is represented by the simple; or quoted field names of the containing fields, delimited by `.`. For; example, the structured field; `"foo" : { map_value: { "x&y" : { string_value: "hello" }}}` would be; represented by the field path `foo.x&y`.; ; Within a field path, a quoted field name starts and ends with `` ` `` and; may contain any character. Some characters, including `` ` ``, must be; escaped using a `\`. For example, `` `x&y` `` represents `x&y` and; `` `bak\`tik` `` represents `` bak`tik ``.
-	Name       *string                  `json:"name,omitempty"`      // The resource name of the document, for example; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-	UpdateTime *string                  `json:"updateTime,omitempty"`// The time at which the document was last changed.; ; This value is initially set to the `create_time` then increases; monotonically with each change to the document. It can also be; compared to values from other documents and the `read_time` of a query.
+	CreateTime *string                  `json:"createTime,omitempty"` // The time at which the document was created.; ; This value increases monotonically when a document is deleted then; recreated. It can also be compared to values from other documents and; the `read_time` of a query.
+	Fields     map[string]OldValueField `json:"fields,omitempty"`     // The document's fields.; ; The map keys represent field names.; ; A simple field name contains only characters `a` to `z`, `A` to `Z`,; `0` to `9`, or `_`, and must not start with `0` to `9`. For example,; `foo_bar_17`.; ; Field names matching the regular expression `__.*__` are reserved. Reserved; field names are forbidden except in certain documented contexts. The map; keys, represented as UTF-8, must not exceed 1,500 bytes and cannot be; empty.; ; Field paths may be used in other contexts to refer to structured fields; defined here. For `map_value`, the field path is represented by the simple; or quoted field names of the containing fields, delimited by `.`. For; example, the structured field; `"foo" : { map_value: { "x&y" : { string_value: "hello" }}}` would be; represented by the field path `foo.x&y`.; ; Within a field path, a quoted field name starts and ends with `` ` `` and; may contain any character. Some characters, including `` ` ``, must be; escaped using a `\`. For example, `` `x&y` `` represents `x&y` and; `` `bak\`tik` `` represents `` bak`tik ``.
+	Name       *string                  `json:"name,omitempty"`       // The resource name of the document, for example; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+	UpdateTime *string                  `json:"updateTime,omitempty"` // The time at which the document was last changed.; ; This value is initially set to the `create_time` then increases; monotonically with each change to the document. It can also be; compared to values from other documents and the `read_time` of a query.
 }
 
 type CreateTime string
+
 const (
 	NullValue CreateTime = "NULL_VALUE"
 )

--- a/cloud/pubsub/v1/message_published_data.go
+++ b/cloud/pubsub/v1/message_published_data.go
@@ -27,7 +27,6 @@ type Message struct {
 	Data        *string           `json:"data,omitempty"`        // The binary data in the message.
 	MessageID   *string           `json:"messageId,omitempty"`   // ID of this message, assigned by the server when the message is published.; Guaranteed to be unique within the topic.
 	PublishTime *string           `json:"publishTime,omitempty"` // The time at which the message was published, populated by the server when; it receives the `Publish` call.
-	Tempbytes   *string           `json:"tempbytes,omitempty"`
 }
 
 func UnmarshalMessagePublishedData(data []byte) (MessagePublishedData, error) {

--- a/cloud/pubsub/v1/message_published_data.go
+++ b/cloud/pubsub/v1/message_published_data.go
@@ -27,6 +27,7 @@ type Message struct {
 	Data        *string           `json:"data,omitempty"`        // The binary data in the message.
 	MessageID   *string           `json:"messageId,omitempty"`   // ID of this message, assigned by the server when the message is published.; Guaranteed to be unique within the topic.
 	PublishTime *string           `json:"publishTime,omitempty"` // The time at which the message was published, populated by the server when; it receives the `Publish` call.
+	Tempbytes   *string           `json:"tempbytes,omitempty"`
 }
 
 func UnmarshalMessagePublishedData(data []byte) (MessagePublishedData, error) {

--- a/cloud/pubsub/v1/message_published_data.go
+++ b/cloud/pubsub/v1/message_published_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,15 +17,16 @@ import "encoding/json"
 
 // The event data when a message is published to a topic.
 type MessagePublishedData struct {
-	Message      *Message `json:"message,omitempty"`     // The message that was published.
-	Subscription *string  `json:"subscription,omitempty"`// The resource name of the subscription for which this event was; generated. The format of the value is; `projects/{project-id}/subscriptions/{subscription-id}`.
+	Message      *Message `json:"message,omitempty"`      // The message that was published.
+	Subscription *string  `json:"subscription,omitempty"` // The resource name of the subscription for which this event was; generated. The format of the value is; `projects/{project-id}/subscriptions/{subscription-id}`.
 }
 
 // The message that was published.
 type Message struct {
-	Attributes map[string]string `json:"attributes,omitempty"`// Attributes for this message.
-	Data       *string           `json:"data,omitempty"`      // The binary data in the message.
-	MessageID  *string           `json:"messageId,omitempty"` // ID of this message, assigned by the server when the message is published.; Guaranteed to be unique within the topic.
+	Attributes  map[string]string `json:"attributes,omitempty"`  // Attributes for this message.
+	Data        *string           `json:"data,omitempty"`        // The binary data in the message.
+	MessageID   *string           `json:"messageId,omitempty"`   // ID of this message, assigned by the server when the message is published.; Guaranteed to be unique within the topic.
+	PublishTime *string           `json:"publishTime,omitempty"` // The time at which the message was published, populated by the server when; it receives the `Publish` call.
 }
 
 func UnmarshalMessagePublishedData(data []byte) (MessagePublishedData, error) {

--- a/cloud/scheduler/v1/scheduler_job_data.go
+++ b/cloud/scheduler/v1/scheduler_job_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ import "encoding/json"
 
 // Scheduler job data.
 type SchedulerJobData struct {
-	CustomData *string `json:"customData,omitempty"`// The custom data the user specified when creating the scheduler source.
+	CustomData *string `json:"customData,omitempty"` // The custom data the user specified when creating the scheduler source.
 }
 
 func UnmarshalSchedulerJobData(data []byte) (SchedulerJobData, error) {

--- a/cloud/storage/v1/storage_object_data.go
+++ b/cloud/storage/v1/storage_object_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,42 +17,42 @@ import "encoding/json"
 
 // An object within Google Cloud Storage.
 type StorageObjectData struct {
-	Bucket                  *string             `json:"bucket,omitempty"`                 // The name of the bucket containing this object.
-	CacheControl            *string             `json:"cacheControl,omitempty"`           // Cache-Control directive for the object data, matching; [https://tools.ietf.org/html/rfc7234#section-5.2"][RFC 7234 §5.2].
-	ComponentCount          *int64              `json:"componentCount,omitempty"`         // Number of underlying components that make up this object. Components are; accumulated by compose operations.; Attempting to set this field will result in an error.
-	ContentDisposition      *string             `json:"contentDisposition,omitempty"`     // Content-Disposition of the object data, matching; [https://tools.ietf.org/html/rfc6266][RFC 6266].
-	ContentEncoding         *string             `json:"contentEncoding,omitempty"`        // Content-Encoding of the object data, matching; [https://tools.ietf.org/html/rfc7231#section-3.1.2.2][RFC 7231 §3.1.2.2]
-	ContentLanguage         *string             `json:"contentLanguage,omitempty"`        // Content-Language of the object data, matching; [https://tools.ietf.org/html/rfc7231#section-3.1.3.2][RFC 7231 §3.1.3.2].
-	ContentType             *string             `json:"contentType,omitempty"`            // Content-Type of the object data, matching; [https://tools.ietf.org/html/rfc7231#section-3.1.1.5][RFC 7231 §3.1.1.5].; If an object is stored without a Content-Type, it is served as; `application/octet-stream`.
-	Crc32C                  *string             `json:"crc32C,omitempty"`                 // CRC32c checksum. For more information about using the CRC32c; checksum, see; [https://cloud.google.com/storage/docs/hashes-etags#_JSONAPI][Hashes and; ETags: Best Practices].
-	CustomerEncryption      *CustomerEncryption `json:"customerEncryption,omitempty"`     // Metadata of customer-supplied encryption key, if the object is encrypted by; such a key.
-	Etag                    *string             `json:"etag,omitempty"`                   // HTTP 1.1 Entity tag for the object. See; [https://tools.ietf.org/html/rfc7232#section-2.3][RFC 7232 §2.3].
-	EventBasedHold          *bool               `json:"eventBasedHold,omitempty"`         // Whether an object is under event-based hold.
-	Generation              *int64              `json:"generation,omitempty"`             // The content generation of this object. Used for object versioning.; Attempting to set this field will result in an error.
-	ID                      *string             `json:"id,omitempty"`                     // The ID of the object, including the bucket name, object name, and; generation number.
-	Kind                    *string             `json:"kind,omitempty"`                   // The kind of item this is. For objects, this is always "storage#object".
-	KmsKeyName              *string             `json:"kmsKeyName,omitempty"`             // Cloud KMS Key used to encrypt this object, if the object is encrypted by; such a key.
-	Md5Hash                 *string             `json:"md5Hash,omitempty"`                // MD5 hash of the data; encoded using base64 as per; [https://tools.ietf.org/html/rfc4648#section-4][RFC 4648 §4]. For more; information about using the MD5 hash, see; [https://cloud.google.com/storage/docs/hashes-etags#_JSONAPI][Hashes and; ETags: Best Practices].
-	MediaLink               *string             `json:"mediaLink,omitempty"`              // Media download link.
-	Metadata                map[string]string   `json:"metadata,omitempty"`               // User-provided metadata, in key/value pairs.
-	Metageneration          *int64              `json:"metageneration,omitempty"`         // The version of the metadata for this object at this generation. Used for; preconditions and for detecting changes in metadata. A metageneration; number is only meaningful in the context of a particular generation of a; particular object.
-	Name                    *string             `json:"name,omitempty"`                   // The name of the object.
-	RetentionExpirationTime *string             `json:"retentionExpirationTime,omitempty"`// A server-determined value that specifies the earliest time that the; object's retention period expires.
-	SelfLink                *string             `json:"selfLink,omitempty"`               // The link to this object.
-	Size                    *int64              `json:"size,omitempty"`                   // Content-Length of the object data in bytes, matching; [https://tools.ietf.org/html/rfc7230#section-3.3.2][RFC 7230 §3.3.2].
-	StorageClass            *string             `json:"storageClass,omitempty"`           // Storage class of the object.
-	TemporaryHold           *bool               `json:"temporaryHold,omitempty"`          // Whether an object is under temporary hold.
-	TimeCreated             *string             `json:"timeCreated,omitempty"`            // The creation time of the object.; Attempting to set this field will result in an error.
-	TimeDeleted             *string             `json:"timeDeleted,omitempty"`            // The deletion time of the object. Will be returned if and only if this; version of the object has been deleted.
-	TimeStorageClassUpdated *string             `json:"timeStorageClassUpdated,omitempty"`// The time at which the object's storage class was last changed.
-	Updated                 *string             `json:"updated,omitempty"`                // The modification time of the object metadata.
+	Bucket                  *string             `json:"bucket,omitempty"`                  // The name of the bucket containing this object.
+	CacheControl            *string             `json:"cacheControl,omitempty"`            // Cache-Control directive for the object data, matching; [https://tools.ietf.org/html/rfc7234#section-5.2"][RFC 7234 §5.2].
+	ComponentCount          *int64              `json:"componentCount,string,omitempty"`   // Number of underlying components that make up this object. Components are; accumulated by compose operations.; Attempting to set this field will result in an error.
+	ContentDisposition      *string             `json:"contentDisposition,omitempty"`      // Content-Disposition of the object data, matching; [https://tools.ietf.org/html/rfc6266][RFC 6266].
+	ContentEncoding         *string             `json:"contentEncoding,omitempty"`         // Content-Encoding of the object data, matching; [https://tools.ietf.org/html/rfc7231#section-3.1.2.2][RFC 7231 §3.1.2.2]
+	ContentLanguage         *string             `json:"contentLanguage,omitempty"`         // Content-Language of the object data, matching; [https://tools.ietf.org/html/rfc7231#section-3.1.3.2][RFC 7231 §3.1.3.2].
+	ContentType             *string             `json:"contentType,omitempty"`             // Content-Type of the object data, matching; [https://tools.ietf.org/html/rfc7231#section-3.1.1.5][RFC 7231 §3.1.1.5].; If an object is stored without a Content-Type, it is served as; `application/octet-stream`.
+	Crc32C                  *string             `json:"crc32C,omitempty"`                  // CRC32c checksum. For more information about using the CRC32c; checksum, see; [https://cloud.google.com/storage/docs/hashes-etags#_JSONAPI][Hashes and; ETags: Best Practices].
+	CustomerEncryption      *CustomerEncryption `json:"customerEncryption,omitempty"`      // Metadata of customer-supplied encryption key, if the object is encrypted by; such a key.
+	Etag                    *string             `json:"etag,omitempty"`                    // HTTP 1.1 Entity tag for the object. See; [https://tools.ietf.org/html/rfc7232#section-2.3][RFC 7232 §2.3].
+	EventBasedHold          *bool               `json:"eventBasedHold,omitempty"`          // Whether an object is under event-based hold.
+	Generation              *int64              `json:"generation,string,omitempty"`       // The content generation of this object. Used for object versioning.; Attempting to set this field will result in an error.
+	ID                      *string             `json:"id,omitempty"`                      // The ID of the object, including the bucket name, object name, and; generation number.
+	Kind                    *string             `json:"kind,omitempty"`                    // The kind of item this is. For objects, this is always "storage#object".
+	KmsKeyName              *string             `json:"kmsKeyName,omitempty"`              // Cloud KMS Key used to encrypt this object, if the object is encrypted by; such a key.
+	Md5Hash                 *string             `json:"md5Hash,omitempty"`                 // MD5 hash of the data; encoded using base64 as per; [https://tools.ietf.org/html/rfc4648#section-4][RFC 4648 §4]. For more; information about using the MD5 hash, see; [https://cloud.google.com/storage/docs/hashes-etags#_JSONAPI][Hashes and; ETags: Best Practices].
+	MediaLink               *string             `json:"mediaLink,omitempty"`               // Media download link.
+	Metadata                map[string]string   `json:"metadata,omitempty"`                // User-provided metadata, in key/value pairs.
+	Metageneration          *int64              `json:"metageneration,string,omitempty"`   // The version of the metadata for this object at this generation. Used for; preconditions and for detecting changes in metadata. A metageneration; number is only meaningful in the context of a particular generation of a; particular object.
+	Name                    *string             `json:"name,omitempty"`                    // The name of the object.
+	RetentionExpirationTime *string             `json:"retentionExpirationTime,omitempty"` // A server-determined value that specifies the earliest time that the; object's retention period expires.
+	SelfLink                *string             `json:"selfLink,omitempty"`                // The link to this object.
+	Size                    *int64              `json:"size,string,omitempty"`             // Content-Length of the object data in bytes, matching; [https://tools.ietf.org/html/rfc7230#section-3.3.2][RFC 7230 §3.3.2].
+	StorageClass            *string             `json:"storageClass,omitempty"`            // Storage class of the object.
+	TemporaryHold           *bool               `json:"temporaryHold,omitempty"`           // Whether an object is under temporary hold.
+	TimeCreated             *string             `json:"timeCreated,omitempty"`             // The creation time of the object.; Attempting to set this field will result in an error.
+	TimeDeleted             *string             `json:"timeDeleted,omitempty"`             // The deletion time of the object. Will be returned if and only if this; version of the object has been deleted.
+	TimeStorageClassUpdated *string             `json:"timeStorageClassUpdated,omitempty"` // The time at which the object's storage class was last changed.
+	Updated                 *string             `json:"updated,omitempty"`                 // The modification time of the object metadata.
 }
 
 // Metadata of customer-supplied encryption key, if the object is encrypted by
 // such a key.
 type CustomerEncryption struct {
-	EncryptionAlgorithm *string `json:"encryptionAlgorithm,omitempty"`// The encryption algorithm.
-	KeySha256           *string `json:"keySha256,omitempty"`          // SHA256 hash value of the encryption key.
+	EncryptionAlgorithm *string `json:"encryptionAlgorithm,omitempty"` // The encryption algorithm.
+	KeySha256           *string `json:"keySha256,omitempty"`           // SHA256 hash value of the encryption key.
 }
 
 func UnmarshalStorageObjectData(data []byte) (StorageObjectData, error) {

--- a/firebase/analytics/v1/analytics_log_data.go
+++ b/firebase/analytics/v1/analytics_log_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,97 +17,97 @@ import "encoding/json"
 
 // The data within Firebase Analytics log events.
 type AnalyticsLogData struct {
-	EventDim []EventDim `json:"eventDim,omitempty"`// A repeated record of event related dimensions.
-	UserDim  *UserDim   `json:"userDim,omitempty"` // User related dimensions.
+	EventDim []EventDim `json:"eventDim,omitempty"` // A repeated record of event related dimensions.
+	UserDim  *UserDim   `json:"userDim,omitempty"`  // User related dimensions.
 }
 
 // Message containing information pertaining to the event.
 type EventDim struct {
-	Date                    *string                   `json:"date,omitempty"`                   // The date on which this event was logged.; (YYYYMMDD format in the registered timezone of your app.)
-	Name                    *string                   `json:"name,omitempty"`                   // The name of this event.
-	Params                  map[string]AnalyticsValue `json:"params,omitempty"`                 // A repeated record of the parameters associated with this event.
-	PreviousTimestampMicros *int64                    `json:"previousTimestampMicros,omitempty"`// UTC client time when the previous event happened.
-	TimestampMicros         *int64                    `json:"timestampMicros,omitempty"`        // UTC client time when the event happened.
-	ValueInUsd              *float64                  `json:"valueInUsd,omitempty"`             // Value param in USD.
+	Date                    *string                   `json:"date,omitempty"`                           // The date on which this event was logged.; (YYYYMMDD format in the registered timezone of your app.)
+	Name                    *string                   `json:"name,omitempty"`                           // The name of this event.
+	Params                  map[string]AnalyticsValue `json:"params,omitempty"`                         // A repeated record of the parameters associated with this event.
+	PreviousTimestampMicros *int64                    `json:"previousTimestampMicros,string,omitempty"` // UTC client time when the previous event happened.
+	TimestampMicros         *int64                    `json:"timestampMicros,string,omitempty"`         // UTC client time when the event happened.
+	ValueInUsd              *float64                  `json:"valueInUsd,omitempty"`                     // Value param in USD.
 }
 
 // Value for Event Params and UserProperty can be of type string or int or
 // float or double.
 type AnalyticsValue struct {
 	DoubleValue *float64 `json:"doubleValue,omitempty"`
-	FloatValue  *float64 `json:"floatValue,omitempty"` 
-	IntValue    *int64   `json:"intValue,omitempty"`   
+	FloatValue  *float64 `json:"floatValue,omitempty"`
+	IntValue    *int64   `json:"intValue,string,omitempty"`
 	StringValue *string  `json:"stringValue,omitempty"`
 }
 
 // User related dimensions.
 type UserDim struct {
-	AppInfo                  *AppInfo                `json:"appInfo,omitempty"`                 // App information.
-	BundleInfo               *BundleInfo             `json:"bundleInfo,omitempty"`              // Information regarding the bundle in which these events were uploaded.
-	DeviceInfo               *DeviceInfo             `json:"deviceInfo,omitempty"`              // Device information.
-	FirstOpenTimestampMicros *int64                  `json:"firstOpenTimestampMicros,omitempty"`// The time (in microseconds) at which the user first opened the app.
-	GeoInfo                  *GeoInfo                `json:"geoInfo,omitempty"`                 // User's geographic information.
-	LtvInfo                  *LtvInfo                `json:"ltvInfo,omitempty"`                 // Lifetime Value information about this user.
-	TrafficSource            *TrafficSource          `json:"trafficSource,omitempty"`           // Information about marketing campaign which acquired the user.
-	UserID                   *string                 `json:"userId,omitempty"`                  // The user ID set via the setUserId API.
-	UserProperties           map[string]UserProperty `json:"userProperties,omitempty"`          // A repeated record of user properties set with the setUserProperty API.; https://firebase.google.com/docs/analytics/android/properties
+	AppInfo                  *AppInfo                `json:"appInfo,omitempty"`                         // App information.
+	BundleInfo               *BundleInfo             `json:"bundleInfo,omitempty"`                      // Information regarding the bundle in which these events were uploaded.
+	DeviceInfo               *DeviceInfo             `json:"deviceInfo,omitempty"`                      // Device information.
+	FirstOpenTimestampMicros *int64                  `json:"firstOpenTimestampMicros,string,omitempty"` // The time (in microseconds) at which the user first opened the app.
+	GeoInfo                  *GeoInfo                `json:"geoInfo,omitempty"`                         // User's geographic information.
+	LtvInfo                  *LtvInfo                `json:"ltvInfo,omitempty"`                         // Lifetime Value information about this user.
+	TrafficSource            *TrafficSource          `json:"trafficSource,omitempty"`                   // Information about marketing campaign which acquired the user.
+	UserID                   *string                 `json:"userId,omitempty"`                          // The user ID set via the setUserId API.
+	UserProperties           map[string]UserProperty `json:"userProperties,omitempty"`                  // A repeated record of user properties set with the setUserProperty API.; https://firebase.google.com/docs/analytics/android/properties
 }
 
 // App information.
 type AppInfo struct {
-	AppID         *string `json:"appId,omitempty"`        // Unique application identifier within an app store.
-	AppInstanceID *string `json:"appInstanceId,omitempty"`// Unique id for this instance of the app.; Example: "71683BF9FA3B4B0D9535A1F05188BAF3"
-	AppPlatform   *string `json:"appPlatform,omitempty"`  // The app platform.; Eg "ANDROID", "IOS".
-	AppStore      *string `json:"appStore,omitempty"`     // The identifier of the store that installed the app.; Eg. "com.sec.android.app.samsungapps", "com.amazon.venezia",; "com.nokia.nstore"
-	AppVersion    *string `json:"appVersion,omitempty"`   // The app's version name; Examples: "1.0", "4.3.1.1.213361", "2.3 (1824253)", "v1.8b22p6"
+	AppID         *string `json:"appId,omitempty"`         // Unique application identifier within an app store.
+	AppInstanceID *string `json:"appInstanceId,omitempty"` // Unique id for this instance of the app.; Example: "71683BF9FA3B4B0D9535A1F05188BAF3"
+	AppPlatform   *string `json:"appPlatform,omitempty"`   // The app platform.; Eg "ANDROID", "IOS".
+	AppStore      *string `json:"appStore,omitempty"`      // The identifier of the store that installed the app.; Eg. "com.sec.android.app.samsungapps", "com.amazon.venezia",; "com.nokia.nstore"
+	AppVersion    *string `json:"appVersion,omitempty"`    // The app's version name; Examples: "1.0", "4.3.1.1.213361", "2.3 (1824253)", "v1.8b22p6"
 }
 
 // Information regarding the bundle in which these events were uploaded.
 type BundleInfo struct {
-	BundleSequenceID            *int64 `json:"bundleSequenceId,omitempty"`           // Monotonically increasing index for each bundle set by SDK.
-	ServerTimestampOffsetMicros *int64 `json:"serverTimestampOffsetMicros,omitempty"`// Timestamp offset between collection time and upload time.
+	BundleSequenceID            *int64 `json:"bundleSequenceId,string,omitempty"`            // Monotonically increasing index for each bundle set by SDK.
+	ServerTimestampOffsetMicros *int64 `json:"serverTimestampOffsetMicros,string,omitempty"` // Timestamp offset between collection time and upload time.
 }
 
 // Device information.
 type DeviceInfo struct {
-	DeviceCategory              *string `json:"deviceCategory,omitempty"`             // Device category.; Eg. tablet or mobile.
-	DeviceID                    *string `json:"deviceId,omitempty"`                   // Vendor specific device identifier. This is IDFV on iOS. Not used for; Android.; Example: "599F9C00-92DC-4B5C-9464-7971F01F8370"
-	DeviceModel                 *string `json:"deviceModel,omitempty"`                // Device model.; Eg. GT-I9192
-	DeviceTimeZoneOffsetSeconds *int64  `json:"deviceTimeZoneOffsetSeconds,omitempty"`// The timezone of the device when data was uploaded as seconds skew from UTC.
-	LimitedAdTracking           *bool   `json:"limitedAdTracking,omitempty"`          // The device's Limit Ad Tracking setting.; When true, we cannot use device_id for remarketing, demographics or; influencing ads serving behaviour. However, we can use device_id for; conversion tracking and campaign attribution.
-	MobileBrandName             *string `json:"mobileBrandName,omitempty"`            // Device brand name.; Eg. Samsung, HTC, etc.
-	MobileMarketingName         *string `json:"mobileMarketingName,omitempty"`        // Device marketing name.; Eg. Galaxy S4 Mini
-	MobileModelName             *string `json:"mobileModelName,omitempty"`            // Device model name.; Eg. GT-I9192
-	PlatformVersion             *string `json:"platformVersion,omitempty"`            // Device OS version when data capture ended.; Eg. 4.4.2
-	ResettableDeviceID          *string `json:"resettableDeviceId,omitempty"`         // The type of the resettable_device_id is always IDFA on iOS and AdId; on Android.; Example: "71683BF9-FA3B-4B0D-9535-A1F05188BAF3"
-	UserDefaultLanguage         *string `json:"userDefaultLanguage,omitempty"`        // The user language.; Eg. "en-us", "en-za", "zh-tw", "jp"
+	DeviceCategory              *string `json:"deviceCategory,omitempty"`                     // Device category.; Eg. tablet or mobile.
+	DeviceID                    *string `json:"deviceId,omitempty"`                           // Vendor specific device identifier. This is IDFV on iOS. Not used for; Android.; Example: "599F9C00-92DC-4B5C-9464-7971F01F8370"
+	DeviceModel                 *string `json:"deviceModel,omitempty"`                        // Device model.; Eg. GT-I9192
+	DeviceTimeZoneOffsetSeconds *int64  `json:"deviceTimeZoneOffsetSeconds,string,omitempty"` // The timezone of the device when data was uploaded as seconds skew from UTC.
+	LimitedAdTracking           *bool   `json:"limitedAdTracking,omitempty"`                  // The device's Limit Ad Tracking setting.; When true, we cannot use device_id for remarketing, demographics or; influencing ads serving behaviour. However, we can use device_id for; conversion tracking and campaign attribution.
+	MobileBrandName             *string `json:"mobileBrandName,omitempty"`                    // Device brand name.; Eg. Samsung, HTC, etc.
+	MobileMarketingName         *string `json:"mobileMarketingName,omitempty"`                // Device marketing name.; Eg. Galaxy S4 Mini
+	MobileModelName             *string `json:"mobileModelName,omitempty"`                    // Device model name.; Eg. GT-I9192
+	PlatformVersion             *string `json:"platformVersion,omitempty"`                    // Device OS version when data capture ended.; Eg. 4.4.2
+	ResettableDeviceID          *string `json:"resettableDeviceId,omitempty"`                 // The type of the resettable_device_id is always IDFA on iOS and AdId; on Android.; Example: "71683BF9-FA3B-4B0D-9535-A1F05188BAF3"
+	UserDefaultLanguage         *string `json:"userDefaultLanguage,omitempty"`                // The user language.; Eg. "en-us", "en-za", "zh-tw", "jp"
 }
 
 // User's geographic information.
 type GeoInfo struct {
-	City      *string `json:"city,omitempty"`     // The geographic city.; Eg. Sao Paulo
-	Continent *string `json:"continent,omitempty"`// The geographic continent.; Eg. Americas
-	Country   *string `json:"country,omitempty"`  // The geographic country.; Eg. Brazil
-	Region    *string `json:"region,omitempty"`   // The geographic region.; Eg. State of Sao Paulo
+	City      *string `json:"city,omitempty"`      // The geographic city.; Eg. Sao Paulo
+	Continent *string `json:"continent,omitempty"` // The geographic continent.; Eg. Americas
+	Country   *string `json:"country,omitempty"`   // The geographic country.; Eg. Brazil
+	Region    *string `json:"region,omitempty"`    // The geographic region.; Eg. State of Sao Paulo
 }
 
 // Lifetime Value information about this user.
 type LtvInfo struct {
-	Currency *string  `json:"currency,omitempty"`// The currency corresponding to the revenue.
-	Revenue  *float64 `json:"revenue,omitempty"` // The Lifetime Value revenue of this user.
+	Currency *string  `json:"currency,omitempty"` // The currency corresponding to the revenue.
+	Revenue  *float64 `json:"revenue,omitempty"`  // The Lifetime Value revenue of this user.
 }
 
 // Information about marketing campaign which acquired the user.
 type TrafficSource struct {
-	UserAcquiredCampaign *string `json:"userAcquiredCampaign,omitempty"`// The name of the campaign which acquired the user.
-	UserAcquiredMedium   *string `json:"userAcquiredMedium,omitempty"`  // The name of the medium which acquired the user.
-	UserAcquiredSource   *string `json:"userAcquiredSource,omitempty"`  // The name of the network which acquired the user.
+	UserAcquiredCampaign *string `json:"userAcquiredCampaign,omitempty"` // The name of the campaign which acquired the user.
+	UserAcquiredMedium   *string `json:"userAcquiredMedium,omitempty"`   // The name of the medium which acquired the user.
+	UserAcquiredSource   *string `json:"userAcquiredSource,omitempty"`   // The name of the network which acquired the user.
 }
 
 type UserProperty struct {
-	Index            *int64 `json:"index,omitempty"`           // Index for user property (one-based).
-	SetTimestampUsec *int64 `json:"setTimestampUsec,omitempty"`// UTC client time when user property was last set.
-	Value            *Value `json:"value,omitempty"`           // Last set value of user property.
+	Index            *int64 `json:"index,string,omitempty"`            // Index for user property (one-based).
+	SetTimestampUsec *int64 `json:"setTimestampUsec,string,omitempty"` // UTC client time when user property was last set.
+	Value            *Value `json:"value,omitempty"`                   // Last set value of user property.
 }
 
 // Last set value of user property.
@@ -116,8 +116,8 @@ type UserProperty struct {
 // float or double.
 type Value struct {
 	DoubleValue *float64 `json:"doubleValue,omitempty"`
-	FloatValue  *float64 `json:"floatValue,omitempty"` 
-	IntValue    *int64   `json:"intValue,omitempty"`   
+	FloatValue  *float64 `json:"floatValue,omitempty"`
+	IntValue    *int64   `json:"intValue,string,omitempty"`
 	StringValue *string  `json:"stringValue,omitempty"`
 }
 

--- a/firebase/auth/v1/auth_event_data.go
+++ b/firebase/auth/v1/auth_event_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,37 +17,37 @@ import "encoding/json"
 
 // The data within all Firebase Auth events.
 type AuthEventData struct {
-	CustomClaims  *CustomClaims   `json:"customClaims,omitempty"` // User's custom claims, typically used to define user roles and propagated; to an authenticated user's ID token.
-	Disabled      *bool           `json:"disabled,omitempty"`     // Whether the user is disabled.
-	DisplayName   *string         `json:"displayName,omitempty"`  // The user's display name.
-	Email         *string         `json:"email,omitempty"`        // The user's primary email, if set.
-	EmailVerified *bool           `json:"emailVerified,omitempty"`// Whether or not the user's primary email is verified.
-	Metadata      *Metadata       `json:"metadata,omitempty"`     // Additional metadata about the user.
-	PhoneNumber   *string         `json:"phoneNumber,omitempty"`  // The user's phone number.
-	PhotoURL      *string         `json:"photoUrl,omitempty"`     // The user's photo URL.
-	ProviderData  []ProviderDatum `json:"providerData,omitempty"` // User's info at the providers
-	Uid           *string         `json:"uid,omitempty"`          // The user identifier in the Firebase app.
+	CustomClaims  *CustomClaims   `json:"customClaims,omitempty"`  // User's custom claims, typically used to define user roles and propagated; to an authenticated user's ID token.
+	Disabled      *bool           `json:"disabled,omitempty"`      // Whether the user is disabled.
+	DisplayName   *string         `json:"displayName,omitempty"`   // The user's display name.
+	Email         *string         `json:"email,omitempty"`         // The user's primary email, if set.
+	EmailVerified *bool           `json:"emailVerified,omitempty"` // Whether or not the user's primary email is verified.
+	Metadata      *Metadata       `json:"metadata,omitempty"`      // Additional metadata about the user.
+	PhoneNumber   *string         `json:"phoneNumber,omitempty"`   // The user's phone number.
+	PhotoURL      *string         `json:"photoUrl,omitempty"`      // The user's photo URL.
+	ProviderData  []ProviderDatum `json:"providerData,omitempty"`  // User's info at the providers
+	Uid           *string         `json:"uid,omitempty"`           // The user identifier in the Firebase app.
 }
 
 // User's custom claims, typically used to define user roles and propagated
 // to an authenticated user's ID token.
 type CustomClaims struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"`// Unordered map of dynamically typed values.
+	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
 // Additional metadata about the user.
 type Metadata struct {
-	CreatedAt      *string `json:"createdAt,omitempty"`     // The date the user was created.
-	LastSignedInAt *string `json:"lastSignedInAt,omitempty"`// The date the user last signed in.
+	CreateTime     *string `json:"createTime,omitempty"`     // The date the user was created.
+	LastSignInTime *string `json:"lastSignInTime,omitempty"` // The date the user last signed in.
 }
 
 // User's info at the identity provider
 type ProviderDatum struct {
-	DisplayName *string `json:"displayName,omitempty"`// The display name for the linked provider.
-	Email       *string `json:"email,omitempty"`      // The email for the linked provider.
-	PhotoURL    *string `json:"photoUrl,omitempty"`   // The photo URL for the linked provider.
-	ProviderID  *string `json:"providerId,omitempty"` // The linked provider ID (e.g. "google.com" for the Google provider).
-	Uid         *string `json:"uid,omitempty"`        // The user identifier for the linked provider.
+	DisplayName *string `json:"displayName,omitempty"` // The display name for the linked provider.
+	Email       *string `json:"email,omitempty"`       // The email for the linked provider.
+	PhotoURL    *string `json:"photoUrl,omitempty"`    // The photo URL for the linked provider.
+	ProviderID  *string `json:"providerId,omitempty"`  // The linked provider ID (e.g. "google.com" for the Google provider).
+	Uid         *string `json:"uid,omitempty"`         // The user identifier for the linked provider.
 }
 
 func UnmarshalAuthEventData(data []byte) (AuthEventData, error) {

--- a/firebase/database/v1/reference_event_data.go
+++ b/firebase/database/v1/reference_event_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ import "encoding/json"
 
 // The data within all Firebase Real Time Database reference events.
 type ReferenceEventData struct {
-	Data  map[string]interface{} `json:"data,omitempty"` // The original data for the reference.
-	Delta map[string]interface{} `json:"delta,omitempty"`// The change in the reference data.
+	Data  map[string]interface{} `json:"data,omitempty"`  // The original data for the reference.
+	Delta map[string]interface{} `json:"delta,omitempty"` // The change in the reference data.
 }
 
 func UnmarshalReferenceEventData(data []byte) (ReferenceEventData, error) {

--- a/firebase/remoteconfig/v1/remote_config_event_data.go
+++ b/firebase/remoteconfig/v1/remote_config_event_data.go
@@ -22,11 +22,12 @@ type RemoteConfigEventData struct {
 	UpdateOrigin   *UpdateOrigin `json:"updateOrigin"`                    // Where the update action originated.
 	UpdateTime     *string       `json:"updateTime,omitempty"`            // When the Remote Config template was written to the Remote Config server.
 	UpdateType     *UpdateType   `json:"updateType"`                      // What type of update was made.
-	UpdateUser     *UpdateUser   `json:"updateUser,omitempty"`            // Aggregation of all metadata fields about the account that performed the update.
+	UpdateUser     *UpdateUser   `json:"updateUser,omitempty"`            // Aggregation of all metadata fields about the account that performed the; update.
 	VersionNumber  *int64        `json:"versionNumber,string,omitempty"`  // The version number of the version's corresponding Remote Config template.
 }
 
-// Aggregation of all metadata fields about the account that performed the update.
+// Aggregation of all metadata fields about the account that performed the
+// update.
 type UpdateUser struct {
 	Email    *string `json:"email,omitempty"`    // Email address.
 	ImageURL *string `json:"imageUrl,omitempty"` // Image URL.

--- a/firebase/remoteconfig/v1/remote_config_event_data.go
+++ b/firebase/remoteconfig/v1/remote_config_event_data.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,36 +17,38 @@ import "encoding/json"
 
 // The data within all Firebase Remote Config events.
 type RemoteConfigEventData struct {
-	Description    *string       `json:"description,omitempty"`   // The user-provided description of the corresponding Remote Config template.
-	RollbackSource *int64        `json:"rollbackSource,omitempty"`// Only present if this version is the result of a rollback, and will be the; version number of the Remote Config template that was rolled-back to.
-	UpdateOrigin   *UpdateOrigin `json:"updateOrigin"`            // Where the update action originated.
-	UpdateTime     *string       `json:"updateTime,omitempty"`    // When the Remote Config template was written to the Remote Config server.
-	UpdateType     *UpdateType   `json:"updateType"`              // What type of update was made.
-	UpdateUser     *UpdateUser   `json:"updateUser,omitempty"`    // Aggregation of all metadata fields about the account that performed the update.
-	VersionNumber  *int64        `json:"versionNumber,omitempty"` // The version number of the version's corresponding Remote Config template.
+	Description    *string       `json:"description,omitempty"`           // The user-provided description of the corresponding Remote Config template.
+	RollbackSource *int64        `json:"rollbackSource,string,omitempty"` // Only present if this version is the result of a rollback, and will be the; version number of the Remote Config template that was rolled-back to.
+	UpdateOrigin   *UpdateOrigin `json:"updateOrigin"`                    // Where the update action originated.
+	UpdateTime     *string       `json:"updateTime,omitempty"`            // When the Remote Config template was written to the Remote Config server.
+	UpdateType     *UpdateType   `json:"updateType"`                      // What type of update was made.
+	UpdateUser     *UpdateUser   `json:"updateUser,omitempty"`            // Aggregation of all metadata fields about the account that performed the update.
+	VersionNumber  *int64        `json:"versionNumber,string,omitempty"`  // The version number of the version's corresponding Remote Config template.
 }
 
 // Aggregation of all metadata fields about the account that performed the update.
 type UpdateUser struct {
-	Email    *string `json:"email,omitempty"`   // Email address.
-	ImageURL *string `json:"imageUrl,omitempty"`// Image URL.
-	Name     *string `json:"name,omitempty"`    // Display name.
+	Email    *string `json:"email,omitempty"`    // Email address.
+	ImageURL *string `json:"imageUrl,omitempty"` // Image URL.
+	Name     *string `json:"name,omitempty"`     // Display name.
 }
 
 type UpdateOriginEnum string
+
 const (
-	AdminSDKNode UpdateOriginEnum = "ADMIN_SDK_NODE"
-	Console UpdateOriginEnum = "CONSOLE"
-	RESTAPI UpdateOriginEnum = "REST_API"
+	AdminSDKNode                        UpdateOriginEnum = "ADMIN_SDK_NODE"
+	Console                             UpdateOriginEnum = "CONSOLE"
+	RESTAPI                             UpdateOriginEnum = "REST_API"
 	RemoteConfigUpdateOriginUnspecified UpdateOriginEnum = "REMOTE_CONFIG_UPDATE_ORIGIN_UNSPECIFIED"
 )
 
 type UpdateTypeEnum string
+
 const (
-	ForcedUpdate UpdateTypeEnum = "FORCED_UPDATE"
-	IncrementalUpdate UpdateTypeEnum = "INCREMENTAL_UPDATE"
+	ForcedUpdate                      UpdateTypeEnum = "FORCED_UPDATE"
+	IncrementalUpdate                 UpdateTypeEnum = "INCREMENTAL_UPDATE"
 	RemoteConfigUpdateTypeUnspecified UpdateTypeEnum = "REMOTE_CONFIG_UPDATE_TYPE_UNSPECIFIED"
-	Rollback UpdateTypeEnum = "ROLLBACK"
+	Rollback                          UpdateTypeEnum = "ROLLBACK"
 )
 
 // Where the update action originated.

--- a/tools/gen.sh
+++ b/tools/gen.sh
@@ -15,8 +15,10 @@ qt \
 cp -a google/events/. .
 rm -r google
 
-echo $ROOT
-
 # Run postgen
-cd tools
-npm start
+echo '- Running postgen step'
+(cd tools && npm start)
+
+# Re-format the golang files
+echo "- Re-format golang files"
+gofmt -s -w .

--- a/tools/src/postgen-64types.ts
+++ b/tools/src/postgen-64types.ts
@@ -1,0 +1,42 @@
+
+/**
+ * This file adds the "string" annotation to all numbers with 64 bits.
+ *
+ * Properties that are numbers with 64 bits are (always) converted into a string
+ * when serialized into JSON.
+ *
+ * @see https://developers.google.com/protocol-buffers/docs/proto3#json
+ *
+ * Note: This library strictly expects JSON serialization for CloudEvent data payloads.
+ *
+ * @example
+ * {
+ *   "generation": "1610564600595212"
+ * }
+ *
+ * To parse these values into an idiomatic value, i.e. an "int64" rather than "string", we modify
+ * the Golang fields for 64 bit types (int64, uint64, float64):
+ *
+ * Before:
+ *     Generation              *int64              `json:"generation,omitempty"`
+ * After:
+ *     Generation              *int64              `json:"generation,string,omitempty"`
+ *
+ * This modification currently cannot be done at the JSON schema + Quicktype level,
+ * as JSON schema does not have a representation for 64 bit numbers serialized as strings.
+ * @param {string} golangFile
+ * @returns {string} The golang file with fixed 64
+ */
+export const fix64BitNumberFields = (golangFile: string) => {
+  const lines = golangFile.split('\n');
+  const patchedLines = lines.map((line: string) => {
+    // For lines that have a 64 bit field
+    if (line.includes('*int64') ||
+        line.includes('*uint64') ||
+        line.includes('*floatint64')) {
+      line = line.replace(",omitempty", ",string,omitempty");
+    }
+    return line;
+  });
+  return patchedLines.join('\n');
+};

--- a/tools/src/postgen-64types.ts
+++ b/tools/src/postgen-64types.ts
@@ -24,6 +24,7 @@
  *
  * This modification currently cannot be done at the JSON schema + Quicktype level,
  * as JSON schema does not have a representation for 64 bit numbers serialized as strings.
+ * @see https://github.com/json-schema-org/json-schema-spec/issues/361
  * @param {string} golangFile
  * @returns {string} The golang file with fixed 64
  */


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloudevents-go/issues/39

See detailed conversation and latest comment here: https://github.com/googleapis/google-cloudevents-go/issues/39#issuecomment-782473649

- Runs the generator.
  - New postgen step: Allows for `string` option in 64 bit types.
- Runs `gofmt` since we just modified golang files (we didn't do this before, so the diff is larger than normal)
  - Another artifact is the the copyright year is updated.

Notice in the Golang code how `*64` types allow the JSON values for 64 bit numbers to be strings (they will always be JSON strings).

Main code to review is in `tools/src/postgen-64types.ts`.

---

Here's a general test you can perform to understand the difference between adding the `string` annotation:

```go
package main

import (
	"encoding/json"
	"fmt"
)

func main() {
	fmt.Println("Test:")

	var d MyType
	s := `{ "port": "1234123341234", "revenue": "34.45"}`
	err := json.Unmarshal([]byte(s), &d)

	if err == nil {
		fmt.Print(*d.Port)
	}
}

// MyType: test
type MyType struct {
	Port *int64 `json:"port,string,omitempty"`
	// Port *int64 `json:"port,omitempty"`
}
```

`go run .`