### PR TITLE
fix!: Improve golang documentation for types and copyright header

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ package main
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 
-	pubsub "github.com/googleapis/google-cloudevents-go/cloud/pubsub/v1"
+	"github.com/googleapis/google-cloudevents-go/cloud/pubsub/v1"
 )
 
 func main() {
@@ -41,7 +42,8 @@ func main() {
     "subscription": "projects/myproject/subscriptions/mysubscription"
   }`)
 
-	e, err := pubsub.UnmarshalMessagePublishedData(data)
+	var e pubsub.MessagePublishedData
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}
@@ -51,7 +53,6 @@ func main() {
 	}
 	fmt.Printf("%+s\n", s)
 }
-
 ```
 
 More detailed documentation about the usage of every type can be found in this library's reference.

--- a/cloud/audit/v1/log_entry_data.go
+++ b/cloud/audit/v1/log_entry_data.go
@@ -11,11 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package audit
 
-import "encoding/json"
-
-// The data within all Cloud Audit Logs log entry events.
+// LogEntryData: The data within all Cloud Audit Logs log entry events.
 type LogEntryData struct {
 	InsertID         *string           `json:"insertId,omitempty"`         // A unique identifier for the log entry.
 	Labels           map[string]string `json:"labels,omitempty"`           // A set of user-defined (key, value) data that provides additional; information about the log entry.
@@ -30,7 +29,7 @@ type LogEntryData struct {
 	Trace            *string           `json:"trace,omitempty"`            // Resource name of the trace associated with the log entry, if any. If it; contains a relative resource name, the name is assumed to be relative to; `//tracing.googleapis.com`. Example:; `projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824`
 }
 
-// Information about an operation associated with the log entry, if
+// Operation: Information about an operation associated with the log entry, if
 // applicable.
 type Operation struct {
 	First    *bool   `json:"first,omitempty"`    // True if this is the first log entry in the operation.
@@ -39,7 +38,7 @@ type Operation struct {
 	Producer *string `json:"producer,omitempty"` // An arbitrary producer identifier. The combination of `id` and; `producer` must be globally unique. Examples for `producer`:; `"MyDivision.MyBigCompany.com"`, `"github.com/MyProject/MyApplication"`.
 }
 
-// The log entry payload, which is always an AuditLog for Cloud Audit Log
+// ProtoPayload: The log entry payload, which is always an AuditLog for Cloud Audit Log
 // events.
 type ProtoPayload struct {
 	AuthenticationInfo    *AuthenticationInfo    `json:"authenticationInfo,omitempty"`      // Authentication information.
@@ -58,7 +57,7 @@ type ProtoPayload struct {
 	Status                *Status                `json:"status,omitempty"`                  // The status of the overall operation.
 }
 
-// Authentication information.
+// AuthenticationInfo: Authentication information.
 type AuthenticationInfo struct {
 	AuthoritySelector            *string                                `json:"authoritySelector,omitempty"`            // The authority selector specified by the requestor, if any.; It is not guaranteed that the principal was allowed to use this authority.
 	PrincipalEmail               *string                                `json:"principalEmail,omitempty"`               // The email address of the authenticated user (or service account on behalf; of third party principal) making the request. For privacy reasons, the; principal email address is redacted for all read-only operations that fail; with a "permission denied" error.
@@ -68,42 +67,42 @@ type AuthenticationInfo struct {
 	ThirdPartyPrincipal          *AuthenticationInfoThirdPartyPrincipal `json:"thirdPartyPrincipal,omitempty"`          // The third party identification (if any) of the authenticated user making; the request.; When the JSON object represented here has a proto equivalent, the proto; name will be indicated in the `@type` property.
 }
 
-// Identity delegation history of an authenticated service account.
+// ServiceAccountDelegationInfo: Identity delegation history of an authenticated service account.
 type ServiceAccountDelegationInfo struct {
 	FirstPartyPrincipal *FirstPartyPrincipal                             `json:"firstPartyPrincipal,omitempty"` // First party (Google) identity as the real authority.
 	ThirdPartyPrincipal *ServiceAccountDelegationInfoThirdPartyPrincipal `json:"thirdPartyPrincipal,omitempty"` // Third party identity as the real authority.
 }
 
-// First party (Google) identity as the real authority.
+// FirstPartyPrincipal: First party (Google) identity as the real authority.
 type FirstPartyPrincipal struct {
 	PrincipalEmail  *string          `json:"principalEmail,omitempty"`  // The email address of a Google account.
 	ServiceMetadata *ServiceMetadata `json:"serviceMetadata,omitempty"` // Metadata about the service that uses the service account.
 }
 
-// Metadata about the service that uses the service account.
+// ServiceMetadata: Metadata about the service that uses the service account.
 type ServiceMetadata struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
+	Fields map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
-// Third party identity as the real authority.
+// ServiceAccountDelegationInfoThirdPartyPrincipal: Third party identity as the real authority.
 type ServiceAccountDelegationInfoThirdPartyPrincipal struct {
 	ThirdPartyClaims *ThirdPartyClaims `json:"thirdPartyClaims,omitempty"` // Metadata about third party identity.
 }
 
-// Metadata about third party identity.
+// ThirdPartyClaims: Metadata about third party identity.
 type ThirdPartyClaims struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
+	Fields map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
-// The third party identification (if any) of the authenticated user making
+// AuthenticationInfoThirdPartyPrincipal: The third party identification (if any) of the authenticated user making
 // the request.
 // When the JSON object represented here has a proto equivalent, the proto
 // name will be indicated in the `@type` property.
 type AuthenticationInfoThirdPartyPrincipal struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
+	Fields map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
-// Authorization information for the operation.
+// AuthorizationInfo: Authorization information for the operation.
 type AuthorizationInfo struct {
 	Granted            *bool               `json:"granted,omitempty"`            // Whether or not authorization for `resource` and `permission`; was granted.
 	Permission         *string             `json:"permission,omitempty"`         // The required IAM permission.
@@ -111,7 +110,7 @@ type AuthorizationInfo struct {
 	ResourceAttributes *ResourceAttributes `json:"resourceAttributes,omitempty"` // Resource attributes used in IAM condition evaluation. This field contains; resource attributes like resource type and resource name.; ; To get the whole view of the attributes used in IAM; condition evaluation, the user must also look into; `AuditLogData.request_metadata.request_attributes`.
 }
 
-// Resource attributes used in IAM condition evaluation. This field contains
+// ResourceAttributes: Resource attributes used in IAM condition evaluation. This field contains
 // resource attributes like resource type and resource name.
 //
 // To get the whole view of the attributes used in IAM
@@ -124,23 +123,23 @@ type ResourceAttributes struct {
 	Type    *string           `json:"type,omitempty"`    // The type of the resource. The syntax is platform-specific because; different platforms define their resources differently.; ; For Google APIs, the type format must be "{service}/{kind}".
 }
 
-// Other service-specific data about the request, response, and other
+// Metadata: Other service-specific data about the request, response, and other
 // information associated with the current audited event.
 type Metadata struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
+	Fields map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
-// The operation request. This may not include all request parameters,
+// Request: The operation request. This may not include all request parameters,
 // such as those that are too large, privacy-sensitive, or duplicated
 // elsewhere in the log record.
 // It should never include user-generated data, such as file contents.
 // When the JSON object represented here has a proto equivalent, the proto
 // name will be indicated in the `@type` property.
 type Request struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
+	Fields map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
-// Metadata about the operation.
+// RequestMetadata: Metadata about the operation.
 type RequestMetadata struct {
 	CallerIP                *string                `json:"callerIp,omitempty"`                // The IP address of the caller.; For caller from internet, this will be public IPv4 or IPv6 address.; For caller from a Compute Engine VM with external IP address, this; will be the VM's external IP address. For caller from a Compute; Engine VM without external IP address, if the VM is in the same; organization (or project) as the accessed resource, `caller_ip` will; be the VM's internal IPv4 address, otherwise the `caller_ip` will be; redacted to "gce-internal-ip".; See https://cloud.google.com/compute/docs/vpc/ for more information.
 	CallerNetwork           *string                `json:"callerNetwork,omitempty"`           // The network of the caller.; Set only if the network host project is part of the same GCP organization; (or project) as the accessed resource.; See https://cloud.google.com/compute/docs/vpc/ for more information.; This is a scheme-less URI full resource name. For example:; ; "//compute.googleapis.com/projects/PROJECT_ID/global/networks/NETWORK_ID"
@@ -149,7 +148,7 @@ type RequestMetadata struct {
 	RequestAttributes       *RequestAttributes     `json:"requestAttributes,omitempty"`       // Request attributes used in IAM condition evaluation. This field contains; request attributes like request time and access levels associated with; the request.; ; ; To get the whole view of the attributes used in IAM; condition evaluation, the user must also look into; `AuditLog.authentication_info.resource_attributes`.
 }
 
-// The destination of a network activity, such as accepting a TCP connection.
+// DestinationAttributes: The destination of a network activity, such as accepting a TCP connection.
 // In a multi hop network activity, the destination represents the receiver of
 // the last hop. Only two fields are used in this message, Peer.port and
 // Peer.ip. These fields are optionally populated by those services utilizing
@@ -162,7 +161,7 @@ type DestinationAttributes struct {
 	RegionCode *string           `json:"regionCode,omitempty"`  // The CLDR country/region code associated with the above IP address.; If the IP address is private, the `region_code` should reflect the; physical location where this peer is running.
 }
 
-// Request attributes used in IAM condition evaluation. This field contains
+// RequestAttributes: Request attributes used in IAM condition evaluation. This field contains
 // request attributes like request time and access levels associated with
 // the request.
 //
@@ -185,7 +184,7 @@ type RequestAttributes struct {
 	Time     *string           `json:"time,omitempty"`        // The timestamp when the `destination` service receives the first byte of; the request.
 }
 
-// The request authentication. May be absent for unauthenticated requests.
+// Auth: The request authentication. May be absent for unauthenticated requests.
 // Derived from the HTTP request `Authorization` header or equivalent.
 type Auth struct {
 	AccessLevels []string `json:"accessLevels,omitempty"` // A list of access level resource names that allow resources to be; accessed by authenticated requester. It is part of Secure GCP processing; for the incoming request. An access level string has the format:; "//{api_service_name}/accessPolicies/{policy_id}/accessLevels/{short_name}"; ; Example:; "//accesscontextmanager.googleapis.com/accessPolicies/MY_POLICY_ID/accessLevels/MY_LEVEL"
@@ -195,7 +194,7 @@ type Auth struct {
 	Principal    *string  `json:"principal,omitempty"`    // The authenticated principal. Reflects the issuer (`iss`) and subject; (`sub`) claims within a JWT. The issuer and subject should be `/`; delimited, with `/` percent-encoded within the subject fragment. For; Google accounts, the principal format is:; "https://accounts.google.com/{id}"
 }
 
-// Structured claims presented with the credential. JWTs include
+// Claims: Structured claims presented with the credential. JWTs include
 // `{key: value}` pairs for standard and private claims. The following
 // is a subset of the standard required and optional claims that would
 // typically be presented for a Google-based JWT:
@@ -211,16 +210,16 @@ type Auth struct {
 // SAML assertions are similarly specified, but with an identity provider
 // dependent structure.
 type Claims struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
+	Fields map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
-// The resource location information.
+// ResourceLocation: The resource location information.
 type ResourceLocation struct {
 	CurrentLocations  []string `json:"currentLocations,omitempty"`  // The locations of a resource after the execution of the operation.; Requests to create or delete a location based resource must populate; the 'current_locations' field and not the 'original_locations' field.; For example:; ; "europe-west1-a"; "us-east1"; "nam3"
 	OriginalLocations []string `json:"originalLocations,omitempty"` // The locations of a resource prior to the execution of the operation.; Requests that mutate the resource's location must populate both the; 'original_locations' as well as the 'current_locations' fields.; For example:; ; "europe-west1-a"; "us-east1"; "nam3"
 }
 
-// The resource's original state before mutation. Present only for
+// ResourceOriginalState: The resource's original state before mutation. Present only for
 // operations which have successfully modified the targeted resource(s).
 // In general, this field should contain all changed fields, except those
 // that are already been included in `request`, `response`, `metadata` or
@@ -228,36 +227,36 @@ type ResourceLocation struct {
 // When the JSON object represented here has a proto equivalent,
 // the proto name will be indicated in the `@type` property.
 type ResourceOriginalState struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
+	Fields map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
-// The operation response. This may not include all response elements,
+// Response: The operation response. This may not include all response elements,
 // such as those that are too large, privacy-sensitive, or duplicated
 // elsewhere in the log record.
 // It should never include user-generated data, such as file contents.
 // When the JSON object represented here has a proto equivalent, the proto
 // name will be indicated in the `@type` property.
 type Response struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
+	Fields map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
-// Deprecated, use `metadata` field instead.
+// ServiceData: Deprecated, use `metadata` field instead.
 // Other service-specific data about the request, response, and other
 // activities.
 // When the JSON object represented here has a proto equivalent, the proto
 // name will be indicated in the `@type` property.
 type ServiceData struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
+	Fields map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
-// The status of the overall operation.
+// Status: The status of the overall operation.
 type Status struct {
 	Code    *int64   `json:"code,string,omitempty"` // The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
 	Details []Detail `json:"details,omitempty"`     // A list of messages that carry the error details.  There is a common set of; message types for APIs to use.
 	Message *string  `json:"message,omitempty"`     // A developer-facing error message, which should be in English. Any; user-facing error message should be localized and sent in the; [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
 }
 
-// `Any` contains an arbitrary serialized protocol buffer message along with a
+// Detail: `Any` contains an arbitrary serialized protocol buffer message along with a
 // URL that describes the type of the serialized message.
 //
 // Protobuf library provides support to pack/unpack Any values in the form
@@ -341,7 +340,7 @@ type Detail struct {
 	Value   *string `json:"value,omitempty"`   // Must be a valid serialized protocol buffer of the above specified type.
 }
 
-// The monitored resource that produced this log entry.
+// Resource: The monitored resource that produced this log entry.
 //
 // Example: a log entry that reports a database error would be associated with
 // the monitored resource designating the particular database that reported
@@ -365,18 +364,8 @@ const (
 	Warning   InsertID = "WARNING"
 )
 
-// The severity of the log entry.
+// Severity: The severity of the log entry.
 type Severity struct {
 	Enum    *InsertID
 	Integer *int64
-}
-
-func UnmarshalLogEntryData(data []byte) (LogEntryData, error) {
-	var d LogEntryData
-	err := json.Unmarshal(data, &d)
-	return d, err
-}
-
-func (p *LogEntryData) MarshalLogEntryData() ([]byte, error) {
-	return json.Marshal(p)
 }

--- a/cloud/cloudbuild/v1/build_event_data.go
+++ b/cloud/cloudbuild/v1/build_event_data.go
@@ -11,11 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cloudbuild
 
-import "encoding/json"
-
-// Build event data for Google Cloud Platform API operations.
+// BuildEventData: Build event data for Google Cloud Platform API operations.
 type BuildEventData struct {
 	Artifacts        *Artifacts             `json:"artifacts,omitempty"`        // Artifacts produced by the build that should be uploaded upon; successful completion of all build steps.
 	BuildTriggerID   *string                `json:"buildTriggerId,omitempty"`   // The ID of the `BuildTrigger` that triggered this build, if it; was triggered automatically.
@@ -42,14 +41,14 @@ type BuildEventData struct {
 	Timing           map[string]TimeSpan    `json:"timing,omitempty"`           // Stores timing information for phases of the build. Valid keys; are:; ; * BUILD: time to execute all build steps; * PUSH: time to push all specified images.; * FETCHSOURCE: time to fetch source.; ; If the build does not specify source or images,; these keys will not be included.
 }
 
-// Artifacts produced by the build that should be uploaded upon
+// Artifacts: Artifacts produced by the build that should be uploaded upon
 // successful completion of all build steps.
 type Artifacts struct {
 	Images  []string `json:"images,omitempty"`  // A list of images to be pushed upon the successful completion of all build; steps.; ; The images will be pushed using the builder service account's credentials.; ; The digests of the pushed images will be stored in the Build resource's; results field.; ; If any of the images fail to be pushed, the build is marked FAILURE.
 	Objects *Objects `json:"objects,omitempty"` // A list of objects to be uploaded to Cloud Storage upon successful; completion of all build steps.; ; Files in the workspace matching specified paths globs will be uploaded to; the specified Cloud Storage location using the builder service account's; credentials.; ; The location and generation of the uploaded objects will be stored in the; Build resource's results field.; ; If any objects fail to be pushed, the build is marked FAILURE.
 }
 
-// A list of objects to be uploaded to Cloud Storage upon successful
+// Objects: A list of objects to be uploaded to Cloud Storage upon successful
 // completion of all build steps.
 //
 // Files in the workspace matching specified paths globs will be uploaded to
@@ -66,7 +65,7 @@ type Objects struct {
 	Timing   *ObjectsTiming `json:"timing,omitempty"`   // Stores timing information for pushing all artifact objects.
 }
 
-// Stores timing information for pushing all artifact objects.
+// ObjectsTiming: Stores timing information for pushing all artifact objects.
 //
 // Start and end times for a build execution phase.
 type ObjectsTiming struct {
@@ -74,7 +73,7 @@ type ObjectsTiming struct {
 	StartTime *string `json:"startTime,omitempty"` // Start of time span.
 }
 
-// Special options for this build.
+// Options: Special options for this build.
 type Options struct {
 	DiskSizeGB            *int64                 `json:"diskSizeGb,string,omitempty"`    // Requested disk size for the VM that runs the build. Note that this is *NOT*; "disk free"; some of the space will be used by the operating system and; build utilities. Also note that this is the minimum disk size that will be; allocated for the build -- the build may run with a larger disk than; requested. At present, the maximum disk size is 1000GB; builds that request; more than the maximum are rejected with an error.
 	Env                   []string               `json:"env,omitempty"`                  // A list of global environment variable definitions that will exist for all; build steps in this build. If a variable is defined in both globally and in; a build step, the variable will use the build step value.; ; The elements are of the form "KEY=VALUE" for the environment variable "KEY"; being given the value "VALUE".
@@ -89,14 +88,14 @@ type Options struct {
 	WorkerPool            *string                `json:"workerPool,omitempty"`           // Option to specify a `WorkerPool` for the build.; Format: projects/{project}/locations/{location}/workerPools/{workerPool}
 }
 
-// Volume describes a Docker container volume which is mounted into build steps
+// Volume: Volume describes a Docker container volume which is mounted into build steps
 // in order to persist files across build step execution.
 type Volume struct {
 	Name *string `json:"name,omitempty"` // Name of the volume to mount.; ; Volume names must be unique per build step and must be valid names for; Docker volumes. Each named volume must be used by at least two build steps.
 	Path *string `json:"path,omitempty"` // Path at which to mount the volume.; ; Paths must be absolute and cannot conflict with other volume paths on the; same build step or with certain reserved volume paths.
 }
 
-// TTL in queue for this build. If provided and the build is enqueued longer
+// QueueTTL: TTL in queue for this build. If provided and the build is enqueued longer
 // than this value, the build will expire and the build status will be
 // `EXPIRED`.
 //
@@ -106,7 +105,7 @@ type QueueTTL struct {
 	Seconds *int64 `json:"seconds,string,omitempty"` // Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
 }
 
-// Results of the build.
+// Results: Results of the build.
 type Results struct {
 	ArtifactManifest *string         `json:"artifactManifest,omitempty"`    // Path to the artifact manifest. Only populated when artifacts are uploaded.
 	ArtifactTiming   *ArtifactTiming `json:"artifactTiming,omitempty"`      // Time to push all non-container artifacts.
@@ -116,7 +115,7 @@ type Results struct {
 	NumArtifacts     *int64          `json:"numArtifacts,string,omitempty"` // Number of artifacts uploaded. Only populated when artifacts are uploaded.
 }
 
-// Time to push all non-container artifacts.
+// ArtifactTiming: Time to push all non-container artifacts.
 //
 // Stores timing information for pushing all artifact objects.
 //
@@ -126,14 +125,14 @@ type ArtifactTiming struct {
 	StartTime *string `json:"startTime,omitempty"` // Start of time span.
 }
 
-// An image built by the pipeline.
+// Image: An image built by the pipeline.
 type Image struct {
 	Digest     *string     `json:"digest,omitempty"`     // Docker Registry 2.0 digest.
 	Name       *string     `json:"name,omitempty"`       // Name used to push the container image to Google Container Registry, as; presented to `docker push`.
 	PushTiming *PushTiming `json:"pushTiming,omitempty"` // Stores timing information for pushing the specified image.
 }
 
-// Stores timing information for pushing the specified image.
+// PushTiming: Stores timing information for pushing the specified image.
 //
 // Stores timing information for pushing all artifact objects.
 //
@@ -143,20 +142,20 @@ type PushTiming struct {
 	StartTime *string `json:"startTime,omitempty"` // Start of time span.
 }
 
-// Pairs a set of secret environment variables containing encrypted
+// Secret: Pairs a set of secret environment variables containing encrypted
 // values with the Cloud KMS key to use to decrypt the value.
 type Secret struct {
 	KmsKeyName *string           `json:"kmsKeyName,omitempty"` // Cloud KMS key name to use to decrypt these envs.
 	SecretEnv  map[string]string `json:"secretEnv,omitempty"`  // Map of environment variable name to its encrypted value.; ; Secret environment variables must be unique across all of a build's; secrets, and must be used by at least one build step. Values can be at most; 64 KB in size. There can be at most 100 secret values across all of a; build's secrets.
 }
 
-// The location of the source files to build.
+// Source: The location of the source files to build.
 type Source struct {
 	RepoSource    *RepoSourceClass    `json:"repoSource,omitempty"`    // If provided, get the source from this location in a Cloud Source; Repository.
 	StorageSource *StorageSourceClass `json:"storageSource,omitempty"` // If provided, get the source from this location in Google Cloud Storage.
 }
 
-// If provided, get the source from this location in a Cloud Source
+// RepoSourceClass: If provided, get the source from this location in a Cloud Source
 // Repository.
 //
 // Location of the source in a Google Cloud Source Repository.
@@ -171,7 +170,7 @@ type RepoSourceClass struct {
 	TagName       *string           `json:"tagName,omitempty"`       // Regex matching tags to build.; ; The syntax of the regular expressions accepted is the syntax accepted by; RE2 and described at https://github.com/google/re2/wiki/Syntax
 }
 
-// If provided, get the source from this location in Google Cloud Storage.
+// StorageSourceClass: If provided, get the source from this location in Google Cloud Storage.
 //
 // Location of the source in an archive file in Google Cloud Storage.
 type StorageSourceClass struct {
@@ -180,7 +179,7 @@ type StorageSourceClass struct {
 	Object     *string `json:"object,omitempty"`            // Google Cloud Storage object containing the source.
 }
 
-// A permanent fixed identifier for source.
+// SourceProvenance: A permanent fixed identifier for source.
 type SourceProvenance struct {
 	FileHashes            map[string]FileHashValue    `json:"fileHashes,omitempty"`            // Hash(es) of the build source, which can be used to verify that; the original source integrity was maintained in the build. Note that; `FileHashes` will only be populated if `BuildOptions` has requested a; `SourceProvenanceHash`.; ; The keys to this map are file paths used as build source and the values; contain the hash values for those files.; ; If the build source came in a single package such as a gzipped tarfile; (`.tar.gz`), the `FileHash` will be for the single path to that file.
 	ResolvedRepoSource    *ResolvedRepoSourceClass    `json:"resolvedRepoSource,omitempty"`    // A copy of the build's `source.repo_source`, if exists, with any; revisions resolved.
@@ -191,13 +190,13 @@ type FileHashValue struct {
 	FileHash []FileHashElement `json:"fileHash,omitempty"` // Collection of file hashes.
 }
 
-// Container message for hash values.
+// FileHashElement: Container message for hash values.
 type FileHashElement struct {
 	Type  *Type   `json:"type"`            // The type of hash that was performed.
 	Value *string `json:"value,omitempty"` // The hash value.
 }
 
-// A copy of the build's `source.repo_source`, if exists, with any
+// ResolvedRepoSourceClass: A copy of the build's `source.repo_source`, if exists, with any
 // revisions resolved.
 //
 // If provided, get the source from this location in a Cloud Source
@@ -215,7 +214,7 @@ type ResolvedRepoSourceClass struct {
 	TagName       *string           `json:"tagName,omitempty"`       // Regex matching tags to build.; ; The syntax of the regular expressions accepted is the syntax accepted by; RE2 and described at https://github.com/google/re2/wiki/Syntax
 }
 
-// A copy of the build's `source.storage_source`, if exists, with any
+// ResolvedStorageSourceClass: A copy of the build's `source.storage_source`, if exists, with any
 // generations resolved.
 //
 // If provided, get the source from this location in Google Cloud Storage.
@@ -227,7 +226,7 @@ type ResolvedStorageSourceClass struct {
 	Object     *string `json:"object,omitempty"`            // Google Cloud Storage object containing the source.
 }
 
-// A step in the build pipeline.
+// Step: A step in the build pipeline.
 type Step struct {
 	Args       []string     `json:"args,omitempty"`       // A list of arguments that will be presented to the step when it is started.; ; If the image used to run the step's container has an entrypoint, the `args`; are used as arguments to that entrypoint. If the image does not define; an entrypoint, the first element in args is used as the entrypoint,; and the remainder will be used as arguments.
 	Dir        *string      `json:"dir,omitempty"`        // Working directory to use when running this step's container.; ; If this value is a relative path, it is relative to the build's working; directory. If this value is absolute, it may be outside the build's working; directory, in which case the contents of the path may not be persisted; across build step executions, unless a `volume` for that path is specified.; ; If the build specifies a `RepoSource` with `dir` and a step with a `dir`,; which specifies an absolute path, the `RepoSource` `dir` is ignored for; the step's execution.
@@ -244,7 +243,7 @@ type Step struct {
 	WaitFor    []string     `json:"waitFor,omitempty"`    // The ID(s) of the step(s) that this build step depends on.; This build step will not start until all the build steps in `wait_for`; have completed successfully. If `wait_for` is empty, this build step will; start when all previous build steps in the `Build.Steps` list have; completed successfully.
 }
 
-// Stores timing information for pulling this build step's
+// PullTiming: Stores timing information for pulling this build step's
 // builder image only.
 //
 // Stores timing information for pushing all artifact objects.
@@ -255,7 +254,7 @@ type PullTiming struct {
 	StartTime *string `json:"startTime,omitempty"` // Start of time span.
 }
 
-// Time limit for executing this build step. If not defined, the step has no
+// StepTimeout: Time limit for executing this build step. If not defined, the step has no
 // time limit and will be allowed to continue to run until either it completes
 // or the build itself times out.
 type StepTimeout struct {
@@ -263,7 +262,7 @@ type StepTimeout struct {
 	Seconds *int64 `json:"seconds,string,omitempty"` // Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
 }
 
-// Stores timing information for executing this build step.
+// StepTiming: Stores timing information for executing this build step.
 //
 // Stores timing information for pushing all artifact objects.
 //
@@ -273,7 +272,7 @@ type StepTiming struct {
 	StartTime *string `json:"startTime,omitempty"` // Start of time span.
 }
 
-// Amount of time that this build should be allowed to run, to second
+// BuildEventDataTimeout: Amount of time that this build should be allowed to run, to second
 // granularity. If this amount of time elapses, work on the build will cease
 // and the build status will be `TIMEOUT`.
 type BuildEventDataTimeout struct {
@@ -281,7 +280,7 @@ type BuildEventDataTimeout struct {
 	Seconds *int64 `json:"seconds,string,omitempty"` // Signed seconds of the span of time. Must be from -315,576,000,000; to +315,576,000,000 inclusive. Note: these bounds are computed from:; 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
 }
 
-// Stores timing information for pushing all artifact objects.
+// TimeSpan: Stores timing information for pushing all artifact objects.
 //
 // Start and end times for a build execution phase.
 type TimeSpan struct {
@@ -349,27 +348,27 @@ const (
 	Working       StatusEnum = "WORKING"
 )
 
-// Option to define build log streaming behavior to Google Cloud
+// LogStreamingOption: Option to define build log streaming behavior to Google Cloud
 // Storage.
 type LogStreamingOption struct {
 	Enum    *LogStreamingOptionEnum
 	Integer *int64
 }
 
-// Option to specify the logging mode, which determines where the logs are
+// Logging: Option to specify the logging mode, which determines where the logs are
 // stored.
 type Logging struct {
 	Enum    *LoggingEnum
 	Integer *int64
 }
 
-// Compute Engine machine type on which to run the build.
+// MachineType: Compute Engine machine type on which to run the build.
 type MachineType struct {
 	Enum    *MachineTypeEnum
 	Integer *int64
 }
 
-// Requested verifiability options.
+// RequestedVerifyOption: Requested verifiability options.
 type RequestedVerifyOption struct {
 	Enum    *RequestedVerifyOptionEnum
 	Integer *int64
@@ -381,14 +380,14 @@ type SourceProvenanceHash struct {
 	Integer *int64
 }
 
-// Option to specify behavior when there is an error in the substitution
+// SubstitutionOption: Option to specify behavior when there is an error in the substitution
 // checks.
 type SubstitutionOption struct {
 	Enum    *SubstitutionOptionEnum
 	Integer *int64
 }
 
-// The type of hash that was performed.
+// Type: The type of hash that was performed.
 type Type struct {
 	Enum    *SourceProvenanceHashEnum
 	Integer *int64
@@ -397,14 +396,4 @@ type Type struct {
 type Status struct {
 	Enum    *StatusEnum
 	Integer *int64
-}
-
-func UnmarshalBuildEventData(data []byte) (BuildEventData, error) {
-	var d BuildEventData
-	err := json.Unmarshal(data, &d)
-	return d, err
-}
-
-func (p *BuildEventData) MarshalBuildEventData() ([]byte, error) {
-	return json.Marshal(p)
 }

--- a/cloud/firestore/v1/document_event_data.go
+++ b/cloud/firestore/v1/document_event_data.go
@@ -11,18 +11,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package firestore
 
-import "encoding/json"
-
-// The data within all Firestore document events.
+// DocumentEventData: The data within all Firestore document events.
 type DocumentEventData struct {
 	OldValue   *OldValue   `json:"oldValue,omitempty"`   // A Document object containing a pre-operation document snapshot.; This is only populated for update and delete events.
 	UpdateMask *UpdateMask `json:"updateMask,omitempty"` // A DocumentMask object that lists changed fields.; This is only populated for update events.
 	Value      *Value      `json:"value,omitempty"`      // A Document object containing a post-operation document snapshot.; This is not populated for delete events. (TODO: check this!)
 }
 
-// A Document object containing a pre-operation document snapshot.
+// OldValue: A Document object containing a pre-operation document snapshot.
 // This is only populated for update and delete events.
 //
 // A Firestore document.
@@ -33,7 +32,7 @@ type OldValue struct {
 	UpdateTime *string                  `json:"updateTime,omitempty"` // The time at which the document was last changed.; ; This value is initially set to the `create_time` then increases; monotonically with each change to the document. It can also be; compared to values from other documents and the `read_time` of a query.
 }
 
-// A message that can hold any of the supported value types.
+// OldValueField: A message that can hold any of the supported value types.
 type OldValueField struct {
 	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
 	BooleanValue   *bool           `json:"booleanValue,omitempty"`        // A boolean value.
@@ -48,7 +47,7 @@ type OldValueField struct {
 	TimestampValue *string         `json:"timestampValue,omitempty"`      // A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
 }
 
-// A message that can hold any of the supported value types.
+// MapValueField: A message that can hold any of the supported value types.
 type MapValueField struct {
 	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
 	BooleanValue   *bool           `json:"booleanValue,omitempty"`        // A boolean value.
@@ -63,12 +62,12 @@ type MapValueField struct {
 	TimestampValue *string         `json:"timestampValue,omitempty"`      // A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
 }
 
-// A map value.
+// MapValue: A map value.
 type MapValue struct {
 	Fields map[string]MapValueField `json:"fields,omitempty"` // The map's fields.; ; The map keys represent field names. Field names matching the regular; expression `__.*__` are reserved. Reserved field names are forbidden except; in certain documented contexts. The map keys, represented as UTF-8, must; not exceed 1,500 bytes and cannot be empty.
 }
 
-// A message that can hold any of the supported value types.
+// ValueElement: A message that can hold any of the supported value types.
 type ValueElement struct {
 	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
 	BooleanValue   *bool           `json:"booleanValue,omitempty"`        // A boolean value.
@@ -83,7 +82,7 @@ type ValueElement struct {
 	TimestampValue *string         `json:"timestampValue,omitempty"`      // A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
 }
 
-// An array value.
+// ArrayValue: An array value.
 //
 // Cannot directly contain another array value, though can contain an
 // map which contains another array.
@@ -91,19 +90,19 @@ type ArrayValue struct {
 	Values []ValueElement `json:"values,omitempty"` // Values in the array.
 }
 
-// A geo point value representing a point on the surface of Earth.
+// GeoPointValue: A geo point value representing a point on the surface of Earth.
 type GeoPointValue struct {
 	Latitude  *float64 `json:"latitude,omitempty"`  // The latitude in degrees. It must be in the range [-90.0, +90.0].
 	Longitude *float64 `json:"longitude,omitempty"` // The longitude in degrees. It must be in the range [-180.0, +180.0].
 }
 
-// A DocumentMask object that lists changed fields.
+// UpdateMask: A DocumentMask object that lists changed fields.
 // This is only populated for update events.
 type UpdateMask struct {
 	FieldPaths []string `json:"fieldPaths,omitempty"` // The list of field paths in the mask.; See [Document.fields][google.cloud.firestore.v1.events.Document.fields]; for a field path syntax reference.
 }
 
-// A Document object containing a post-operation document snapshot.
+// Value: A Document object containing a post-operation document snapshot.
 // This is not populated for delete events. (TODO: check this!)
 //
 // A Document object containing a pre-operation document snapshot.
@@ -123,18 +122,8 @@ const (
 	NullValue CreateTime = "NULL_VALUE"
 )
 
-// A null value.
+// NullValueUnion: A null value.
 type NullValueUnion struct {
 	Enum    *CreateTime
 	Integer *int64
-}
-
-func UnmarshalDocumentEventData(data []byte) (DocumentEventData, error) {
-	var d DocumentEventData
-	err := json.Unmarshal(data, &d)
-	return d, err
-}
-
-func (p *DocumentEventData) MarshalDocumentEventData() ([]byte, error) {
-	return json.Marshal(p)
 }

--- a/cloud/pubsub/v1/message_published_data.go
+++ b/cloud/pubsub/v1/message_published_data.go
@@ -11,30 +11,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package pubsub
 
-import "encoding/json"
-
-// The event data when a message is published to a topic.
+// MessagePublishedData: The event data when a message is published to a topic.
 type MessagePublishedData struct {
 	Message      *Message `json:"message,omitempty"`      // The message that was published.
 	Subscription *string  `json:"subscription,omitempty"` // The resource name of the subscription for which this event was; generated. The format of the value is; `projects/{project-id}/subscriptions/{subscription-id}`.
 }
 
-// The message that was published.
+// Message: The message that was published.
 type Message struct {
 	Attributes  map[string]string `json:"attributes,omitempty"`  // Attributes for this message.
 	Data        *string           `json:"data,omitempty"`        // The binary data in the message.
 	MessageID   *string           `json:"messageId,omitempty"`   // ID of this message, assigned by the server when the message is published.; Guaranteed to be unique within the topic.
 	PublishTime *string           `json:"publishTime,omitempty"` // The time at which the message was published, populated by the server when; it receives the `Publish` call.
-}
-
-func UnmarshalMessagePublishedData(data []byte) (MessagePublishedData, error) {
-	var d MessagePublishedData
-	err := json.Unmarshal(data, &d)
-	return d, err
-}
-
-func (p *MessagePublishedData) MarshalMessagePublishedData() ([]byte, error) {
-	return json.Marshal(p)
 }

--- a/cloud/scheduler/v1/scheduler_job_data.go
+++ b/cloud/scheduler/v1/scheduler_job_data.go
@@ -11,21 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package scheduler
 
-import "encoding/json"
-
-// Scheduler job data.
+// SchedulerJobData: Scheduler job data.
 type SchedulerJobData struct {
 	CustomData *string `json:"customData,omitempty"` // The custom data the user specified when creating the scheduler source.
-}
-
-func UnmarshalSchedulerJobData(data []byte) (SchedulerJobData, error) {
-	var d SchedulerJobData
-	err := json.Unmarshal(data, &d)
-	return d, err
-}
-
-func (p *SchedulerJobData) MarshalSchedulerJobData() ([]byte, error) {
-	return json.Marshal(p)
 }

--- a/cloud/storage/v1/storage_object_data.go
+++ b/cloud/storage/v1/storage_object_data.go
@@ -11,11 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package storage
 
-import "encoding/json"
-
-// An object within Google Cloud Storage.
+// StorageObjectData: An object within Google Cloud Storage.
 type StorageObjectData struct {
 	Bucket                  *string             `json:"bucket,omitempty"`                  // The name of the bucket containing this object.
 	CacheControl            *string             `json:"cacheControl,omitempty"`            // Cache-Control directive for the object data, matching; [https://tools.ietf.org/html/rfc7234#section-5.2"][RFC 7234 §5.2].
@@ -48,19 +47,9 @@ type StorageObjectData struct {
 	Updated                 *string             `json:"updated,omitempty"`                 // The modification time of the object metadata.
 }
 
-// Metadata of customer-supplied encryption key, if the object is encrypted by
+// CustomerEncryption: Metadata of customer-supplied encryption key, if the object is encrypted by
 // such a key.
 type CustomerEncryption struct {
 	EncryptionAlgorithm *string `json:"encryptionAlgorithm,omitempty"` // The encryption algorithm.
 	KeySha256           *string `json:"keySha256,omitempty"`           // SHA256 hash value of the encryption key.
-}
-
-func UnmarshalStorageObjectData(data []byte) (StorageObjectData, error) {
-	var d StorageObjectData
-	err := json.Unmarshal(data, &d)
-	return d, err
-}
-
-func (p *StorageObjectData) MarshalStorageObjectData() ([]byte, error) {
-	return json.Marshal(p)
 }

--- a/firebase/analytics/v1/analytics_log_data.go
+++ b/firebase/analytics/v1/analytics_log_data.go
@@ -11,17 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package analytics
 
-import "encoding/json"
-
-// The data within Firebase Analytics log events.
+// AnalyticsLogData: The data within Firebase Analytics log events.
 type AnalyticsLogData struct {
 	EventDim []EventDim `json:"eventDim,omitempty"` // A repeated record of event related dimensions.
 	UserDim  *UserDim   `json:"userDim,omitempty"`  // User related dimensions.
 }
 
-// Message containing information pertaining to the event.
+// EventDim: Message containing information pertaining to the event.
 type EventDim struct {
 	Date                    *string                   `json:"date,omitempty"`                           // The date on which this event was logged.; (YYYYMMDD format in the registered timezone of your app.)
 	Name                    *string                   `json:"name,omitempty"`                           // The name of this event.
@@ -31,7 +30,7 @@ type EventDim struct {
 	ValueInUsd              *float64                  `json:"valueInUsd,omitempty"`                     // Value param in USD.
 }
 
-// Value for Event Params and UserProperty can be of type string or int or
+// AnalyticsValue: Value for Event Params and UserProperty can be of type string or int or
 // float or double.
 type AnalyticsValue struct {
 	DoubleValue *float64 `json:"doubleValue,omitempty"`
@@ -40,7 +39,7 @@ type AnalyticsValue struct {
 	StringValue *string  `json:"stringValue,omitempty"`
 }
 
-// User related dimensions.
+// UserDim: User related dimensions.
 type UserDim struct {
 	AppInfo                  *AppInfo                `json:"appInfo,omitempty"`                         // App information.
 	BundleInfo               *BundleInfo             `json:"bundleInfo,omitempty"`                      // Information regarding the bundle in which these events were uploaded.
@@ -53,7 +52,7 @@ type UserDim struct {
 	UserProperties           map[string]UserProperty `json:"userProperties,omitempty"`                  // A repeated record of user properties set with the setUserProperty API.; https://firebase.google.com/docs/analytics/android/properties
 }
 
-// App information.
+// AppInfo: App information.
 type AppInfo struct {
 	AppID         *string `json:"appId,omitempty"`         // Unique application identifier within an app store.
 	AppInstanceID *string `json:"appInstanceId,omitempty"` // Unique id for this instance of the app.; Example: "71683BF9FA3B4B0D9535A1F05188BAF3"
@@ -62,13 +61,13 @@ type AppInfo struct {
 	AppVersion    *string `json:"appVersion,omitempty"`    // The app's version name; Examples: "1.0", "4.3.1.1.213361", "2.3 (1824253)", "v1.8b22p6"
 }
 
-// Information regarding the bundle in which these events were uploaded.
+// BundleInfo: Information regarding the bundle in which these events were uploaded.
 type BundleInfo struct {
 	BundleSequenceID            *int64 `json:"bundleSequenceId,string,omitempty"`            // Monotonically increasing index for each bundle set by SDK.
 	ServerTimestampOffsetMicros *int64 `json:"serverTimestampOffsetMicros,string,omitempty"` // Timestamp offset between collection time and upload time.
 }
 
-// Device information.
+// DeviceInfo: Device information.
 type DeviceInfo struct {
 	DeviceCategory              *string `json:"deviceCategory,omitempty"`                     // Device category.; Eg. tablet or mobile.
 	DeviceID                    *string `json:"deviceId,omitempty"`                           // Vendor specific device identifier. This is IDFV on iOS. Not used for; Android.; Example: "599F9C00-92DC-4B5C-9464-7971F01F8370"
@@ -83,7 +82,7 @@ type DeviceInfo struct {
 	UserDefaultLanguage         *string `json:"userDefaultLanguage,omitempty"`                // The user language.; Eg. "en-us", "en-za", "zh-tw", "jp"
 }
 
-// User's geographic information.
+// GeoInfo: User's geographic information.
 type GeoInfo struct {
 	City      *string `json:"city,omitempty"`      // The geographic city.; Eg. Sao Paulo
 	Continent *string `json:"continent,omitempty"` // The geographic continent.; Eg. Americas
@@ -91,13 +90,13 @@ type GeoInfo struct {
 	Region    *string `json:"region,omitempty"`    // The geographic region.; Eg. State of Sao Paulo
 }
 
-// Lifetime Value information about this user.
+// LtvInfo: Lifetime Value information about this user.
 type LtvInfo struct {
 	Currency *string  `json:"currency,omitempty"` // The currency corresponding to the revenue.
 	Revenue  *float64 `json:"revenue,omitempty"`  // The Lifetime Value revenue of this user.
 }
 
-// Information about marketing campaign which acquired the user.
+// TrafficSource: Information about marketing campaign which acquired the user.
 type TrafficSource struct {
 	UserAcquiredCampaign *string `json:"userAcquiredCampaign,omitempty"` // The name of the campaign which acquired the user.
 	UserAcquiredMedium   *string `json:"userAcquiredMedium,omitempty"`   // The name of the medium which acquired the user.
@@ -110,7 +109,7 @@ type UserProperty struct {
 	Value            *Value `json:"value,omitempty"`                   // Last set value of user property.
 }
 
-// Last set value of user property.
+// Value: Last set value of user property.
 //
 // Value for Event Params and UserProperty can be of type string or int or
 // float or double.
@@ -119,14 +118,4 @@ type Value struct {
 	FloatValue  *float64 `json:"floatValue,omitempty"`
 	IntValue    *int64   `json:"intValue,string,omitempty"`
 	StringValue *string  `json:"stringValue,omitempty"`
-}
-
-func UnmarshalAnalyticsLogData(data []byte) (AnalyticsLogData, error) {
-	var d AnalyticsLogData
-	err := json.Unmarshal(data, &d)
-	return d, err
-}
-
-func (p *AnalyticsLogData) MarshalAnalyticsLogData() ([]byte, error) {
-	return json.Marshal(p)
 }

--- a/firebase/auth/v1/auth_event_data.go
+++ b/firebase/auth/v1/auth_event_data.go
@@ -11,11 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package auth
 
-import "encoding/json"
-
-// The data within all Firebase Auth events.
+// AuthEventData: The data within all Firebase Auth events.
 type AuthEventData struct {
 	CustomClaims  *CustomClaims   `json:"customClaims,omitempty"`  // User's custom claims, typically used to define user roles and propagated; to an authenticated user's ID token.
 	Disabled      *bool           `json:"disabled,omitempty"`      // Whether the user is disabled.
@@ -29,33 +28,23 @@ type AuthEventData struct {
 	Uid           *string         `json:"uid,omitempty"`           // The user identifier in the Firebase app.
 }
 
-// User's custom claims, typically used to define user roles and propagated
+// CustomClaims: User's custom claims, typically used to define user roles and propagated
 // to an authenticated user's ID token.
 type CustomClaims struct {
-	Fields map[string]map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
+	Fields map[string]interface{} `json:"fields,omitempty"` // Unordered map of dynamically typed values.
 }
 
-// Additional metadata about the user.
+// Metadata: Additional metadata about the user.
 type Metadata struct {
 	CreateTime     *string `json:"createTime,omitempty"`     // The date the user was created.
 	LastSignInTime *string `json:"lastSignInTime,omitempty"` // The date the user last signed in.
 }
 
-// User's info at the identity provider
+// ProviderDatum: User's info at the identity provider
 type ProviderDatum struct {
 	DisplayName *string `json:"displayName,omitempty"` // The display name for the linked provider.
 	Email       *string `json:"email,omitempty"`       // The email for the linked provider.
 	PhotoURL    *string `json:"photoURL,omitempty"`    // The photo URL for the linked provider.
 	ProviderID  *string `json:"providerId,omitempty"`  // The linked provider ID (e.g. "google.com" for the Google provider).
 	Uid         *string `json:"uid,omitempty"`         // The user identifier for the linked provider.
-}
-
-func UnmarshalAuthEventData(data []byte) (AuthEventData, error) {
-	var d AuthEventData
-	err := json.Unmarshal(data, &d)
-	return d, err
-}
-
-func (p *AuthEventData) MarshalAuthEventData() ([]byte, error) {
-	return json.Marshal(p)
 }

--- a/firebase/database/v1/reference_event_data.go
+++ b/firebase/database/v1/reference_event_data.go
@@ -11,22 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package database
 
-import "encoding/json"
-
-// The data within all Firebase Real Time Database reference events.
+// ReferenceEventData: The data within all Firebase Real Time Database reference events.
 type ReferenceEventData struct {
 	Data  map[string]interface{} `json:"data,omitempty"`  // The original data for the reference.
 	Delta map[string]interface{} `json:"delta,omitempty"` // The change in the reference data.
-}
-
-func UnmarshalReferenceEventData(data []byte) (ReferenceEventData, error) {
-	var d ReferenceEventData
-	err := json.Unmarshal(data, &d)
-	return d, err
-}
-
-func (p *ReferenceEventData) MarshalReferenceEventData() ([]byte, error) {
-	return json.Marshal(p)
 }

--- a/firebase/remoteconfig/v1/remote_config_event_data.go
+++ b/firebase/remoteconfig/v1/remote_config_event_data.go
@@ -11,11 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package remoteconfig
 
-import "encoding/json"
-
-// The data within all Firebase Remote Config events.
+// RemoteConfigEventData: The data within all Firebase Remote Config events.
 type RemoteConfigEventData struct {
 	Description    *string       `json:"description,omitempty"`           // The user-provided description of the corresponding Remote Config template.
 	RollbackSource *int64        `json:"rollbackSource,string,omitempty"` // Only present if this version is the result of a rollback, and will be the; version number of the Remote Config template that was rolled-back to.
@@ -26,7 +25,7 @@ type RemoteConfigEventData struct {
 	VersionNumber  *int64        `json:"versionNumber,string,omitempty"`  // The version number of the version's corresponding Remote Config template.
 }
 
-// Aggregation of all metadata fields about the account that performed the
+// UpdateUser: Aggregation of all metadata fields about the account that performed the
 // update.
 type UpdateUser struct {
 	Email    *string `json:"email,omitempty"`    // Email address.
@@ -52,24 +51,14 @@ const (
 	Rollback                          UpdateTypeEnum = "ROLLBACK"
 )
 
-// Where the update action originated.
+// UpdateOrigin: Where the update action originated.
 type UpdateOrigin struct {
 	Enum    *UpdateOriginEnum
 	Integer *int64
 }
 
-// What type of update was made.
+// UpdateType: What type of update was made.
 type UpdateType struct {
 	Enum    *UpdateTypeEnum
 	Integer *int64
-}
-
-func UnmarshalRemoteConfigEventData(data []byte) (RemoteConfigEventData, error) {
-	var d RemoteConfigEventData
-	err := json.Unmarshal(data, &d)
-	return d, err
-}
-
-func (p *RemoteConfigEventData) MarshalRemoteConfigEventData() ([]byte, error) {
-	return json.Marshal(p)
 }

--- a/reference.md
+++ b/reference.md
@@ -5,29 +5,29 @@ The following sections describe how to use this library with different event dat
 <!-- GENERATED START -->
 ### Cloud Audit Logs
 
-Generic log entry, used as a wrapper for Cloud Audit Logs in events.
- This is copied from
- https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto
- and adapted appropriately.
+The data within all Cloud Audit Logs log entry events.
 
 #### CloudEvent Types:
 
 - `google.cloud.audit.log.v1.written`
 
 #### Sample
+
 ```go
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
-	audit "github.com/googleapis/google-cloudevents-go/cloud/audit/v1"
+	"github.com/googleapis/google-cloudevents-go/cloud/audit/v1"
 )
 
 func main() {
 	data := []byte("CloudEvent Data in bytes")
 
-	e, err := audit.UnmarshalLogEntryData(data)
+	var e audit.LogEntryData
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}
@@ -37,29 +37,29 @@ func main() {
 
 ### Cloud Build
 
-Build event data
- Common build format for Google Cloud Platform API operations.
- Copied from
- https://github.com/googleapis/googleapis/blob/master/google/devtools/cloudbuild/v1/cloudbuild.proto.
+Build event data for Google Cloud Platform API operations.
 
 #### CloudEvent Types:
 
 - `google.cloud.cloudbuild.build.v1.statusChanged`
 
 #### Sample
+
 ```go
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
-	cloudbuild "github.com/googleapis/google-cloudevents-go/cloud/cloudbuild/v1"
+	"github.com/googleapis/google-cloudevents-go/cloud/cloudbuild/v1"
 )
 
 func main() {
 	data := []byte("CloudEvent Data in bytes")
 
-	e, err := cloudbuild.UnmarshalBuildEventData(data)
+	var e cloudbuild.BuildEventData
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}
@@ -79,19 +79,22 @@ The data within all Firestore document events.
 - `google.cloud.firestore.document.v1.written`
 
 #### Sample
+
 ```go
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
-	firestore "github.com/googleapis/google-cloudevents-go/cloud/firestore/v1"
+	"github.com/googleapis/google-cloudevents-go/cloud/firestore/v1"
 )
 
 func main() {
 	data := []byte("CloudEvent Data in bytes")
 
-	e, err := firestore.UnmarshalDocumentEventData(data)
+	var e firestore.DocumentEventData
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}
@@ -101,26 +104,29 @@ func main() {
 
 ### Cloud Pub/Sub
 
-The data received in an event when a message is published to a topic.
+The event data when a message is published to a topic.
 
 #### CloudEvent Types:
 
 - `google.cloud.pubsub.topic.v1.messagePublished`
 
 #### Sample
+
 ```go
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
-	pubsub "github.com/googleapis/google-cloudevents-go/cloud/pubsub/v1"
+	"github.com/googleapis/google-cloudevents-go/cloud/pubsub/v1"
 )
 
 func main() {
 	data := []byte("CloudEvent Data in bytes")
 
-	e, err := pubsub.UnmarshalMessagePublishedData(data)
+	var e pubsub.MessagePublishedData
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}
@@ -137,19 +143,22 @@ Scheduler job data.
 - `google.cloud.scheduler.job.v1.executed`
 
 #### Sample
+
 ```go
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
-	scheduler "github.com/googleapis/google-cloudevents-go/cloud/scheduler/v1"
+	"github.com/googleapis/google-cloudevents-go/cloud/scheduler/v1"
 )
 
 func main() {
 	data := []byte("CloudEvent Data in bytes")
 
-	e, err := scheduler.UnmarshalSchedulerJobData(data)
+	var e scheduler.SchedulerJobData
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}
@@ -169,19 +178,22 @@ An object within Google Cloud Storage.
 - `google.cloud.storage.object.v1.metadataUpdated`
 
 #### Sample
+
 ```go
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
-	storage "github.com/googleapis/google-cloudevents-go/cloud/storage/v1"
+	"github.com/googleapis/google-cloudevents-go/cloud/storage/v1"
 )
 
 func main() {
 	data := []byte("CloudEvent Data in bytes")
 
-	e, err := storage.UnmarshalStorageObjectData(data)
+	var e storage.StorageObjectData
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}
@@ -198,19 +210,22 @@ The data within Firebase Analytics log events.
 - `google.firebase.analytics.log.v1.written`
 
 #### Sample
+
 ```go
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
-	analytics "github.com/googleapis/google-cloudevents-go/firebase/analytics/v1"
+	"github.com/googleapis/google-cloudevents-go/firebase/analytics/v1"
 )
 
 func main() {
 	data := []byte("CloudEvent Data in bytes")
 
-	e, err := analytics.UnmarshalAnalyticsLogData(data)
+	var e analytics.AnalyticsLogData
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}
@@ -220,7 +235,7 @@ func main() {
 
 ### Firebase Authentication
 
-The data within all Firebase Auth events
+The data within all Firebase Auth events.
 
 #### CloudEvent Types:
 
@@ -228,19 +243,22 @@ The data within all Firebase Auth events
 - `google.firebase.auth.user.v1.deleted`
 
 #### Sample
+
 ```go
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
-	auth "github.com/googleapis/google-cloudevents-go/firebase/auth/v1"
+	"github.com/googleapis/google-cloudevents-go/firebase/auth/v1"
 )
 
 func main() {
 	data := []byte("CloudEvent Data in bytes")
 
-	e, err := auth.UnmarshalAuthEventData(data)
+	var e auth.AuthEventData
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}
@@ -260,19 +278,22 @@ The data within all Firebase Real Time Database reference events.
 - `google.firebase.database.ref.v1.written`
 
 #### Sample
+
 ```go
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
-	database "github.com/googleapis/google-cloudevents-go/firebase/database/v1"
+	"github.com/googleapis/google-cloudevents-go/firebase/database/v1"
 )
 
 func main() {
 	data := []byte("CloudEvent Data in bytes")
 
-	e, err := database.UnmarshalReferenceEventData(data)
+	var e database.ReferenceEventData
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}
@@ -289,19 +310,22 @@ The data within all Firebase Remote Config events.
 - `google.firebase.remoteconfig.remoteConfig.v1.updated`
 
 #### Sample
+
 ```go
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
-	remoteconfig "github.com/googleapis/google-cloudevents-go/firebase/remoteconfig/v1"
+	"github.com/googleapis/google-cloudevents-go/firebase/remoteconfig/v1"
 )
 
 func main() {
 	data := []byte("CloudEvent Data in bytes")
 
-	e, err := remoteconfig.UnmarshalRemoteConfigEventData(data)
+	var e remoteconfig.RemoteConfigEventData
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}

--- a/samples/main.go
+++ b/samples/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 
-	pubsub "github.com/googleapis/google-cloudevents-go/cloud/pubsub/v1"
+	"github.com/googleapis/google-cloudevents-go/cloud/pubsub/v1"
 )
 
 func main() {
@@ -19,7 +20,8 @@ func main() {
     "subscription": "projects/myproject/subscriptions/mysubscription"
   }`)
 
-	e, err := pubsub.UnmarshalMessagePublishedData(data)
+	var e pubsub.MessagePublishedData
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/src/docs.ts
+++ b/tools/src/docs.ts
@@ -40,19 +40,22 @@ ${schema.description}
 ${schema.cloudeventTypes?.map((t: string) => `- \`${t}\``).join('\n')}
 
 #### Sample
+
 \`\`\`go
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
-	${goPackage} "${goPath}"
+	"${goPath}"
 )
 
 func main() {
 	data := []byte("CloudEvent Data in bytes")
 
-	e, err := ${goPackage}.Unmarshal${schema.name}(data)
+	var e ${goPackage}.${schema.name}
+	err := json.Unmarshal(data, &e)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/src/postgen-64types.ts
+++ b/tools/src/postgen-64types.ts
@@ -1,4 +1,3 @@
-
 /**
  * This file adds the "string" annotation to all numbers with 64 bits.
  *

--- a/tools/src/postgen.ts
+++ b/tools/src/postgen.ts
@@ -12,29 +12,10 @@ const recursive = require("recursive-readdir");
  * 
  * After gen, this postgen scripts modififies the files this way:
  * - Add package based on folder + version (i.e. "pubsubv1")
- * - Add 'import "encoding/json"' for unmashal function
- * - Add "Unmarshal(data []byte)" function
- * - Add "(d *MyData) Marshal() ([]byte error)" function
  */
 
 // The abs path of the repo root
 const REPO_ROOT = path.dirname(process.cwd());
-
-/**
- * Creates the Unmarshal and Marshal functions for this struct.
- * @param {string} dataFieldName The Pascal Case data name.
- * @example marshalUnmarshalFunctions('MessagePublishedData')
- */
-const marshalUnmarshalFunctions = (dataFieldName: string) => `
-func Unmarshal${dataFieldName}(data []byte) (${dataFieldName}, error) {
-	var d ${dataFieldName}
-	err := json.Unmarshal(data, &d)
-	return d, err
-}
-
-func (p *${dataFieldName}) Marshal${dataFieldName}() ([]byte, error) {
-	return json.Marshal(p)
-}`;
 
 /**
  * Runs post-gen processing on the generated files:
@@ -51,9 +32,12 @@ async function main() {
   // For each schema
   filePaths.forEach(filePath => {
     // Read file
-    const typeFileContent = fs.readFileSync(filePath).toString();
-    const fixedFileContents = fix64BitNumberFields(typeFileContent);
-
+    const [typeFileContent] = [fs.readFileSync(filePath).toString()]
+      .map(fix64BitNumberFields)
+      .map(fixMapStringToInterface)
+      .map(fixTypeGoDocPrefix)
+    ;
+    
     // Get relative path info
     const relativePath = filePath.substr(REPO_ROOT.length + 1);
 
@@ -68,29 +52,70 @@ async function main() {
     // OUT: dataFilename = StorageObjectData.go
     const splitPath = relativePath.split('/');
     const [goPackage, version, dataFilename] = splitPath.slice(-3); // last 3 elements
-    
-    // Create the full file
-    const typeFileWithMarshalling = 
-      fixedFileContents +
-      marshalUnmarshalFunctions(dataField);
 
-    // Add Go package header (but under Apache header)
+    // Add Go package header (but under Apache header, with newline)
     const filePackageHeader =
-`package ${goPackage}
-
-import "encoding/json"`;
-    let typeFileWithMarshallingAndPackage =
-      typeFileWithMarshalling.split('\n');
-    typeFileWithMarshallingAndPackage.splice(
+`
+package ${goPackage}
+`;
+    let typeFileWithPackage =
+    typeFileContent.split('\n');
+    typeFileWithPackage.splice(
       13, // length of Apache header from quicktype wrapper
       0, // don't delete anything
       filePackageHeader, // insert header at this index
     );
-    const typeFile = typeFileWithMarshallingAndPackage.join('\n');
+    const typeFile = typeFileWithPackage.join('\n');
 
     // Write final type file
     fs.writeFileSync(filePath, typeFile);
   });
+}
+
+/**
+ * Converts:
+ * - map[string]map[string]interface{}
+ * to
+ * - map[string]interface{}
+ * @param {string} s The string to update.
+ */
+function fixMapStringToInterface(s: string): string {
+  const mapStringToStringToInterface = 'map[string]map[string]interface{}';
+  const mapStringToInterface = 'map[string]interface{}';
+  return s.split(mapStringToStringToInterface).join(mapStringToInterface);
+}
+
+/**
+ * Prefixes a golang type with "TypeName: " to match golang convention.
+ * @param {string} file The file as a string.
+ * @returns {string} The file with each type prefixed with the type name.
+ */
+function fixTypeGoDocPrefix(file: string): string {
+  const lines = file.split('\n');
+  lines.forEach((line: string, i: number) => {
+    // If we're defining a struct, there must be a comment!
+    // Update the comment.
+    if (line.includes(' struct {')) {
+      const typeName = line.split(' ')[1];
+      // Look back at the comments until we hit the a blank newline
+      let commentIndex = i - 1;
+      while (lines[commentIndex].startsWith('//')) {
+        --commentIndex;
+      }
+      // If there was no comment before the type, there is nothing to fix. Return.
+      if (commentIndex === i - 1) return;
+
+      // We want the line _after_ the blank line (this is the first line of the comment)
+      ++commentIndex;
+
+      // Add the "TypeName: " string at the first line
+      // Before: "// Last set value of user property."
+      // After: "// Value: Last set value of user property."
+      const updateLine = `// ${typeName}: ${lines[commentIndex].substr('// '.length)}`;
+      lines[commentIndex] = updateLine;
+    }
+  });
+  return lines.join('\n');
 }
 
 main();


### PR DESCRIPTION
## fix!: Improve golang documentation for types and copyright header

Based on a mini Golang friction log, this PR addresses many GitHub issues filed in this repo regarding Go usability and style.

This is a breaking change (can use semantic commit message when merging).

### Details

- Adds newline between copyright header and package declaration
  - Fixes: https://github.com/googleapis/google-cloudevents-go/issues/45
- Prefixes each struct with the name per golang convention
  - Fixes: https://github.com/googleapis/google-cloudevents-go/issues/46
- Removes custom unmarshaler functions
  - Fixes: https://github.com/googleapis/google-cloudevents-go/issues/48
- Updates main README documentation and reference documentation taking into account the above updates