### PR TITLE
feat!: use byte types for bytes proto fields

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,11 +29,19 @@ Guidelines](https://opensource.google/conduct/).
 
 ## Generating the Library
 
-**Note**: Before generating the package, set up Node.js 12+.
+### Prerequisites
 
-To generate this package, run
+- Clone this repo
+- Clone `https://github.com/googleapis/google-cloudevents` in the same directory as this repo
+- Install Node.js 12+
+- Install the `qt` CLI globally: https://github.com/googleapis/google-cloudevents/tree/master/tools/quicktype-wrapper
+
+### Generate
+
+To generate this package, run the following script:
 
 ``` sh
-chmod +x ./tools/gen.sh
 ./tools/gen.sh
 ```
+
+This will generate the source code for this repo.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 [![GoDoc](https://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://pkg.go.dev/mod/github.com/googleapis/google-cloudevents-go) [![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
 
+This library provides Go types for Google CloudEvent data.
 
-This library provides classes of common event types used with Google services.
+## Features
+
+- Simple import and interface
+- Inline documentation for Go structs
+- 64 bit number parsing
+- Automatic decoded of base64 data
 
 ## Installation
 
@@ -17,7 +23,7 @@ go get -u github.com/googleapis/google-cloudevents-go
 
 ## Example Usage
 
-Here's an exmaple of using this library with an event from Cloud Pub/Sub with data `MessagePublishedData`.
+Example event of type `MessagePublishedData` from Cloud Pub/Sub.
 
 ```go
 package main

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library provides Go types for Google CloudEvent data.
 - Simple import and interface
 - Inline documentation for Go structs
 - 64 bit number parsing
-- Automatic decoded of base64 data
+- Automatic decoding of base64 data
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Here's an exmaple of using this library with an event from Cloud Pub/Sub with da
 package main
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -36,7 +35,7 @@ func main() {
       "attributes": {
         "key": "value"
       },
-      "data": "Q2xvdWQgUHViL1N1Yg==",
+      "data": "SGVsbG8sIFdvcmxkIQ==",
       "messageId": "136969346945"
     },
     "subscription": "projects/myproject/subscriptions/mysubscription"
@@ -47,11 +46,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	s, err := base64.URLEncoding.DecodeString(*e.Message.Data)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("%+s\n", s)
+	fmt.Printf("%+s\n", e.Message.Data) // Hello, World!
 }
 ```
 

--- a/cloud/cloudbuild/v1/build_event_data.go
+++ b/cloud/cloudbuild/v1/build_event_data.go
@@ -192,8 +192,8 @@ type FileHashValue struct {
 
 // FileHashElement: Container message for hash values.
 type FileHashElement struct {
-	Type  *Type   `json:"type"`            // The type of hash that was performed.
-	Value *string `json:"value,omitempty"` // The hash value.
+	Type  *Type  `json:"type"`            // The type of hash that was performed.
+	Value []byte `json:"value,omitempty"` // The hash value.
 }
 
 // ResolvedRepoSourceClass: A copy of the build's `source.repo_source`, if exists, with any

--- a/cloud/firestore/v1/document_event_data.go
+++ b/cloud/firestore/v1/document_event_data.go
@@ -36,7 +36,7 @@ type OldValue struct {
 type OldValueField struct {
 	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
 	BooleanValue   *bool           `json:"booleanValue,omitempty"`        // A boolean value.
-	BytesValue     *string         `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
+	BytesValue     []byte          `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
 	DoubleValue    *float64        `json:"doubleValue,omitempty"`         // A double value.
 	GeoPointValue  *GeoPointValue  `json:"geoPointValue,omitempty"`       // A geo point value representing a point on the surface of Earth.
 	IntegerValue   *int64          `json:"integerValue,string,omitempty"` // An integer value.
@@ -51,7 +51,7 @@ type OldValueField struct {
 type MapValueField struct {
 	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
 	BooleanValue   *bool           `json:"booleanValue,omitempty"`        // A boolean value.
-	BytesValue     *string         `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
+	BytesValue     []byte          `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
 	DoubleValue    *float64        `json:"doubleValue,omitempty"`         // A double value.
 	GeoPointValue  *GeoPointValue  `json:"geoPointValue,omitempty"`       // A geo point value representing a point on the surface of Earth.
 	IntegerValue   *int64          `json:"integerValue,string,omitempty"` // An integer value.
@@ -71,7 +71,7 @@ type MapValue struct {
 type ValueElement struct {
 	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
 	BooleanValue   *bool           `json:"booleanValue,omitempty"`        // A boolean value.
-	BytesValue     *string         `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
+	BytesValue     []byte          `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
 	DoubleValue    *float64        `json:"doubleValue,omitempty"`         // A double value.
 	GeoPointValue  *GeoPointValue  `json:"geoPointValue,omitempty"`       // A geo point value representing a point on the surface of Earth.
 	IntegerValue   *int64          `json:"integerValue,string,omitempty"` // An integer value.

--- a/cloud/pubsub/v1/message_published_data.go
+++ b/cloud/pubsub/v1/message_published_data.go
@@ -23,7 +23,7 @@ type MessagePublishedData struct {
 // Message: The message that was published.
 type Message struct {
 	Attributes  map[string]string `json:"attributes,omitempty"`  // Attributes for this message.
-	Data        *string           `json:"data,omitempty"`        // The binary data in the message.
+	Data        []byte            `json:"data,omitempty"`        // The binary data in the message.
 	MessageID   *string           `json:"messageId,omitempty"`   // ID of this message, assigned by the server when the message is published.; Guaranteed to be unique within the topic.
 	PublishTime *string           `json:"publishTime,omitempty"` // The time at which the message was published, populated by the server when; it receives the `Publish` call.
 }

--- a/cloud/scheduler/v1/scheduler_job_data.go
+++ b/cloud/scheduler/v1/scheduler_job_data.go
@@ -16,5 +16,5 @@ package scheduler
 
 // SchedulerJobData: Scheduler job data.
 type SchedulerJobData struct {
-	CustomData *string `json:"customData,omitempty"` // The custom data the user specified when creating the scheduler source.
+	CustomData []byte `json:"customData,omitempty"` // The custom data the user specified when creating the scheduler source.
 }

--- a/samples/main.go
+++ b/samples/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -14,7 +13,7 @@ func main() {
       "attributes": {
         "key": "value"
       },
-      "data": "Q2xvdWQgUHViL1N1Yg==",
+      "data": "SGVsbG8sIFdvcmxkIQ==",
       "messageId": "136969346945"
     },
     "subscription": "projects/myproject/subscriptions/mysubscription"
@@ -25,9 +24,5 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	s, err := base64.URLEncoding.DecodeString(*e.Message.Data)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("%+s\n", s)
+	fmt.Printf("%+s\n", e.Message.Data)
 }

--- a/tools/src/postgen-64types.ts
+++ b/tools/src/postgen-64types.ts
@@ -25,7 +25,7 @@
  * as JSON schema does not have a representation for 64 bit numbers serialized as strings.
  * @see https://github.com/json-schema-org/json-schema-spec/issues/361
  * @param {string} golangFile
- * @returns {string} The golang file with fixed 64
+ * @returns {string} The golang file with fixed 64 bit number fields
  */
 export const fix64BitNumberFields = (golangFile: string) => {
   const lines = golangFile.split('\n');

--- a/tools/src/postgen-bytetypes.ts
+++ b/tools/src/postgen-bytetypes.ts
@@ -1,0 +1,86 @@
+const pascalcase = require('pascalcase');
+
+/**
+ * This file converts string types with:
+ * - byte data
+ * to
+ * - byte types
+ *
+ * ## Example
+ * ### Before
+ * type Message struct {
+ *   Data        *string        `json:"data,omitempty"`        // The binary data in the message.
+ * }
+ * 
+ * ### After
+ * type Message struct {
+ *   Data        []byte        `json:"data,omitempty"`        // The binary data in the message.
+ * }
+ * 
+ * Also handles repeated proto fields.
+ * 
+ * ---
+ * 
+ * Does this by inspecting the proto, and modifing the source where appropriate.
+ * 
+ * This modification currently cannot be done at the JSON schema + Quicktype level,
+ * as JSON schema + Quicktype does create base64 formatted strings.
+ * @see https://github.com/quicktype/quicktype/issues/138
+ * @param {string} golangFile The golang file source code
+ * @param {string} protoFile The proto source
+ * @returns {string} The golang file with fixed base64 fields
+ */
+export const fixByteFields = (golangFile: string, protoFile: string) => {
+  // A proto line with bytes
+  type LineWithByte = {
+    field: string;
+    isRepeated: boolean;
+  };
+  
+  // Get all proto lines with the "bytes" type:
+  const protoLines = protoFile.split('\n');
+  const protoLinesWithBytes: LineWithByte[] = [];
+  protoLines.map((line: string) => {
+    /**
+     * Include lines
+     * @example repeated bytes build_step_outputs = 6;
+     * @example bytes data = 1;
+     * @example bytes custom_data = 1;
+     */
+    const isBytes = line.includes('  bytes ');
+    const isRepeatedBytes = line.includes('  repeated bytes ');
+    if (isBytes || isRepeatedBytes) {
+      // The field is right before the " = " sign:
+      const fieldTokens = line.split(' = ')[0].split(' ');
+      const field = pascalcase(fieldTokens[fieldTokens.length - 1]);
+      
+      // Add the line to the array
+      protoLinesWithBytes.push({
+        field,
+        isRepeated: isRepeatedBytes,
+      });
+    }
+  });
+
+  // For all proto "bytes" fields,
+  // Change the type to []byte instead of *string.
+  let updatedGolangFile = golangFile;
+  protoLinesWithBytes.forEach((byteLine: LineWithByte) => {
+    // Replace the golang field with the same name
+    updatedGolangFile = golangFile.split('\n').map((golangLine: string, i: number) => {
+      // Match on the exact field (with tab and space)
+      const lineIncludesFieldname = golangLine.includes(`	${byteLine.field} `);
+      if (lineIncludesFieldname) {
+        if (byteLine.isRepeated) {
+          // If repeated proto bytes, replace the type "[]string" to "[][]byte"
+          return golangLine.replace('[]string', '[][]byte');
+        } else {
+          // If non-repeated proto bytes, replace the type "*string" to "[]byte"
+          return golangLine.replace('*string', '[]byte');
+        }
+      }
+      return golangLine;
+    }).join('\n');
+  });
+  return updatedGolangFile;
+};

--- a/tools/src/postgen-bytetypes.ts
+++ b/tools/src/postgen-bytetypes.ts
@@ -42,7 +42,10 @@ export const fixByteFields = (golangFile: string, protoFile: string) => {
   const protoLinesWithBytes: LineWithByte[] = [];
   protoLines.map((line: string) => {
     /**
-     * Include lines
+     * Include lines from our proto files.
+     * The two spaces in front are part of the file identifiers as we do not do AST parsing.
+     * An eventual solution to this would be to fix the byte fields upstream in the jsonschema
+     * and quicktype generators.
      * @example repeated bytes build_step_outputs = 6;
      * @example bytes data = 1;
      * @example bytes custom_data = 1;


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloudevents-go/issues/49

## Summary

This breaking change adds native `[]byte` array types to proto `byte` fields. (There are around 7 of them.) As a result, it is easier for users to decode byte data this way. 

## Features

- Uses `[]byte` type for fields where appropriate for native base64 unmarshalling.
- Updates code sample to use this updated field type.
- Add clear features documentation with list of features (such as native base64 decoding).

## Note

The post-gen script should be heavily documented, and the transformation functions (like `fixByteFields`) should be in a functional coding style (inputs and outputs).