### PR TITLE
ci: add test for pub/sub sample

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test
+      run: go test ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x]
-        os: [ubuntu-latest, macos-latest]
+        go-version: [1.11.x, 1.16.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go

--- a/cloud/pubsub/v1/message_published_data_test.go
+++ b/cloud/pubsub/v1/message_published_data_test.go
@@ -1,0 +1,56 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubsub
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestMessagePublishedData(t *testing.T) {
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	data := []byte(`{
+    "message": {
+      "attributes": {
+        "key": "value"
+      },
+      "data": "SGVsbG8sIFdvcmxkIQ==",
+      "messageId": "136969346945"
+    },
+    "subscription": "projects/myproject/subscriptions/mysubscription"
+  }`)
+
+	var e MessagePublishedData
+	err := json.Unmarshal(data, &e)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+s", e.Message.Data)
+
+	w.Close()
+	out, _ := ioutil.ReadAll(r)
+	os.Stdout = rescueStdout
+
+	if string(out) != "Hello, World!" {
+		t.Errorf("Expected %s, got %s", "Hello, World!", out)
+	}
+}

--- a/cloud/pubsub/v1/message_published_data_test.go
+++ b/cloud/pubsub/v1/message_published_data_test.go
@@ -36,9 +36,8 @@ func TestMessagePublishedData(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	data := string(e.Message.Data)
 
-	if data != "Hello, World!" {
+	if data := string(e.Message.Data); data != "Hello, World!" {
 		t.Errorf("Expected %s, got %s", "Hello, World!", data)
 	}
 }

--- a/cloud/pubsub/v1/message_published_data_test.go
+++ b/cloud/pubsub/v1/message_published_data_test.go
@@ -16,18 +16,11 @@ package pubsub
 
 import (
 	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 )
 
 func TestMessagePublishedData(t *testing.T) {
-	rescueStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	data := []byte(`{
+	pubsub_data := []byte(`{
     "message": {
       "attributes": {
         "key": "value"
@@ -39,18 +32,13 @@ func TestMessagePublishedData(t *testing.T) {
   }`)
 
 	var e MessagePublishedData
-	err := json.Unmarshal(data, &e)
+	err := json.Unmarshal(pubsub_data, &e)
 	if err != nil {
 		panic(err)
 	}
+	data := string(e.Message.Data)
 
-	fmt.Printf("%+s", e.Message.Data)
-
-	w.Close()
-	out, _ := ioutil.ReadAll(r)
-	os.Stdout = rescueStdout
-
-	if string(out) != "Hello, World!" {
-		t.Errorf("Expected %s, got %s", "Hello, World!", out)
+	if data != "Hello, World!" {
+		t.Errorf("Expected %s, got %s", "Hello, World!", data)
 	}
 }

--- a/tools/src/postgen.ts
+++ b/tools/src/postgen.ts
@@ -29,10 +29,11 @@ const PROTO_ROOT = path.resolve(REPO_ROOT, '..', 'google-cloudevents', 'proto');
  * Runs post-gen processing on the generated files.
  */
 async function main() {
+  // Get all golang files, but ignore test files.
   const filePaths: string[] = [
     ...await recursive(`${REPO_ROOT}/cloud`),
     ...await recursive(`${REPO_ROOT}/firebase`),
-  ];
+  ].filter((filename: string) => !filename.includes('_test.go'));
   
   // For each schema
   filePaths.forEach(filePath => {


### PR DESCRIPTION
Per sync with @grayside, to ensure stability of this repo, we should add automated testing.

This PR adds basic GitHub CI testing for the Pub/Sub event type with a sample Pub/Sub payload.

We add the tests directly next to the file as typical (we need to slightly touch the postgen script to make this work).

Fixes: https://github.com/googleapis/google-cloudevents-go/issues/60