### PR TITLE
build: tag release PR with `autorelease: published`

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,3 @@
 handleGHRelease: true
 releaseType: go
+releaseLabel: "autorelease: published"


### PR DESCRIPTION
When release-please creates the GitHub release, tag the release pull request with `autorelease: published` rather than `autorelease: tagged`.

New feature added in: https://github.com/googleapis/repo-automation-bots/pull/1750

This take the place of the GitHub actions workflow trying to untag `autorelease: tagged` and retag with `autorelease: published`