### PR TITLE
docs: remove unstable badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google CloudEvents - Go
 
-[![GoDoc](https://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://pkg.go.dev/mod/github.com/googleapis/google-cloudevents-go) [![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
+[![GoDoc](https://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://pkg.go.dev/mod/github.com/googleapis/google-cloudevents-go)
 
 This library provides Go types for Google CloudEvent data.
 


### PR DESCRIPTION
We're using the new Go release-please for versioning. This repo is not getting many updates.

When merged, can update https://github.com/GoogleCloudPlatform/golang-samples/pull/2049.