### PR TITLE
feat! treats jsonschema enums as strings for golang generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This library provides Go types for Google CloudEvent data.
 - Inline documentation for Go structs
 - 64 bit number parsing
 - Automatic decoding of base64 data
+- Enum support
 
 ## Installation
 

--- a/cloud/audit/v1/log_entry_data.go
+++ b/cloud/audit/v1/log_entry_data.go
@@ -23,7 +23,7 @@ type LogEntryData struct {
 	ProtoPayload     *ProtoPayload     `json:"protoPayload,omitempty"`     // The log entry payload, which is always an AuditLog for Cloud Audit Log; events.
 	ReceiveTimestamp *string           `json:"receiveTimestamp,omitempty"` // The time the log entry was received by Logging.
 	Resource         *Resource         `json:"resource,omitempty"`         // The monitored resource that produced this log entry.; ; Example: a log entry that reports a database error would be associated with; the monitored resource designating the particular database that reported; the error.
-	Severity         *Severity         `json:"severity"`                   // The severity of the log entry.
+	Severity         *Severity         `json:"severity,omitempty"`         // The severity of the log entry.
 	SpanID           *string           `json:"spanId,omitempty"`           // The span ID within the trace associated with the log entry, if any.; ; For Trace spans, this is the same format that the Trace API v2 uses: a; 16-character hexadecimal encoding of an 8-byte array, such as; `000000000000004a`.
 	Timestamp        *string           `json:"timestamp,omitempty"`        // The time the event described by the log entry occurred.
 	Trace            *string           `json:"trace,omitempty"`            // Resource name of the trace associated with the log entry, if any. If it; contains a relative resource name, the name is assumed to be relative to; `//tracing.googleapis.com`. Example:; `projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824`
@@ -350,22 +350,17 @@ type Resource struct {
 	Type   *string           `json:"type,omitempty"`   // Required. The monitored resource type. For example, the type of a; Compute Engine VM instance is `gce_instance`.
 }
 
-type InsertID string
+// The severity of the log entry.
+type Severity string
 
 const (
-	Alert     InsertID = "ALERT"
-	Critical  InsertID = "CRITICAL"
-	Debug     InsertID = "DEBUG"
-	Default   InsertID = "DEFAULT"
-	Emergency InsertID = "EMERGENCY"
-	Error     InsertID = "ERROR"
-	Info      InsertID = "INFO"
-	Notice    InsertID = "NOTICE"
-	Warning   InsertID = "WARNING"
+	Alert     Severity = "ALERT"
+	Critical  Severity = "CRITICAL"
+	Debug     Severity = "DEBUG"
+	Default   Severity = "DEFAULT"
+	Emergency Severity = "EMERGENCY"
+	Error     Severity = "ERROR"
+	Info      Severity = "INFO"
+	Notice    Severity = "NOTICE"
+	Warning   Severity = "WARNING"
 )
-
-// Severity: The severity of the log entry.
-type Severity struct {
-	Enum    *InsertID
-	Integer *int64
-}

--- a/cloud/audit/v1/log_entry_data_test.go
+++ b/cloud/audit/v1/log_entry_data_test.go
@@ -1,0 +1,90 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// https://cloud.google.com/eventarc/docs/cloudevents
+func TestMessagePublishedData(t *testing.T) {
+	pubsub_data := []byte(`{
+		"protoPayload": {
+			"status": {},
+			"authenticationInfo": {},
+			"requestMetadata": {
+				"callerIp": "...",
+				"callerSuppliedUserAgent": "...",
+				"requestAttributes": {
+					"time": "YYYY-MM-DDThh:mm:ss.sZ",
+					"auth": {}
+				},
+				"destinationAttributes": {}
+			},
+			"serviceName": "storage.googleapis.com",
+			"methodName": "storage.objects.create",
+			"authorizationInfo": [
+				{
+					"resource": "projects/_/buckets/MY_BUCKET/objects/MY_FILE.txt",
+					"permission": "storage.objects.create",
+					"granted": true,
+					"resourceAttributes": {}
+				},
+				{
+					"resource": "projects/_/buckets/MY_BUCKET/objects/MY_FILE.txt",
+					"permission": "storage.objects.delete",
+					"granted": true,
+					"resourceAttributes": {}
+				}
+			],
+			"resourceName": "projects/_/buckets/MY_PROJECT/objects/MY_FILE.txt",
+			"serviceData": {
+				"policyDelta": {
+					"bindingDeltas": []
+				},
+				"@type": "type.googleapis.com/google.iam.v1.logging.AuditData"
+			},
+			"resourceLocation": {
+				"currentLocations": [
+					"us-central1"
+				]
+			}
+		},
+		"insertId": "-qklu1af11306y",
+		"resource": {
+			"type": "gcs_bucket",
+			"labels": {
+				"location": "us-central1",
+				"bucket_name": "MY_BUCKET",
+				"project_id": "MY_PROJECT"
+			}
+		},
+		"timestamp": "2021-04-09T17:57:16.718915757Z",
+		"severity": "INFO",
+		"logName": "projects/MY_PROJECT/logs/cloudaudit.googleapis.com%2Fdata_access",
+		"receiveTimestamp": "2021-04-09T17:57:17.748555474Z"
+	}`)
+
+	var e LogEntryData
+	err := json.Unmarshal(pubsub_data, &e)
+	if err != nil {
+		panic(err)
+	}
+
+	if data := string(*e.Severity); data != "INFO" {
+		t.Errorf("Expected %s, got %s", "INFO", data)
+	}
+}

--- a/cloud/cloudbuild/v1/build_event_data.go
+++ b/cloud/cloudbuild/v1/build_event_data.go
@@ -32,7 +32,7 @@ type BuildEventData struct {
 	Source           *Source                `json:"source,omitempty"`           // The location of the source files to build.
 	SourceProvenance *SourceProvenance      `json:"sourceProvenance,omitempty"` // A permanent fixed identifier for source.
 	StartTime        *string                `json:"startTime,omitempty"`        // Time at which execution of the build was started.
-	Status           *Status                `json:"status"`                     // Status of the build.
+	Status           *Status                `json:"status,omitempty"`           // Status of the build.
 	StatusDetail     *string                `json:"statusDetail,omitempty"`     // Customer-readable message about the current status.
 	Steps            []Step                 `json:"steps,omitempty"`            // The operations to be performed on the workspace.
 	Substitutions    map[string]string      `json:"substitutions,omitempty"`    // Substitutions data for `Build` resource.
@@ -75,17 +75,17 @@ type ObjectsTiming struct {
 
 // Options: Special options for this build.
 type Options struct {
-	DiskSizeGB            *int64                 `json:"diskSizeGb,string,omitempty"`    // Requested disk size for the VM that runs the build. Note that this is *NOT*; "disk free"; some of the space will be used by the operating system and; build utilities. Also note that this is the minimum disk size that will be; allocated for the build -- the build may run with a larger disk than; requested. At present, the maximum disk size is 1000GB; builds that request; more than the maximum are rejected with an error.
-	Env                   []string               `json:"env,omitempty"`                  // A list of global environment variable definitions that will exist for all; build steps in this build. If a variable is defined in both globally and in; a build step, the variable will use the build step value.; ; The elements are of the form "KEY=VALUE" for the environment variable "KEY"; being given the value "VALUE".
-	Logging               *Logging               `json:"logging"`                        // Option to specify the logging mode, which determines where the logs are; stored.
-	LogStreamingOption    *LogStreamingOption    `json:"logStreamingOption"`             // Option to define build log streaming behavior to Google Cloud; Storage.
-	MachineType           *MachineType           `json:"machineType"`                    // Compute Engine machine type on which to run the build.
-	RequestedVerifyOption *RequestedVerifyOption `json:"requestedVerifyOption"`          // Requested verifiability options.
-	SecretEnv             []string               `json:"secretEnv,omitempty"`            // A list of global environment variables, which are encrypted using a Cloud; Key Management Service crypto key. These values must be specified in the; build's `Secret`. These variables will be available to all build steps; in this build.
-	SourceProvenanceHash  []SourceProvenanceHash `json:"sourceProvenanceHash,omitempty"` // Requested hash for SourceProvenance.
-	SubstitutionOption    *SubstitutionOption    `json:"substitutionOption"`             // Option to specify behavior when there is an error in the substitution; checks.
-	Volumes               []Volume               `json:"volumes,omitempty"`              // Global list of volumes to mount for ALL build steps; ; Each volume is created as an empty volume prior to starting the build; process. Upon completion of the build, volumes and their contents are; discarded. Global volume names and paths cannot conflict with the volumes; defined a build step.; ; Using a global volume in a build with only one step is not valid as; it is indicative of a build request with an incorrect configuration.
-	WorkerPool            *string                `json:"workerPool,omitempty"`           // Option to specify a `WorkerPool` for the build.; Format: projects/{project}/locations/{location}/workerPools/{workerPool}
+	DiskSizeGB            *int64                 `json:"diskSizeGb,string,omitempty"`     // Requested disk size for the VM that runs the build. Note that this is *NOT*; "disk free"; some of the space will be used by the operating system and; build utilities. Also note that this is the minimum disk size that will be; allocated for the build -- the build may run with a larger disk than; requested. At present, the maximum disk size is 1000GB; builds that request; more than the maximum are rejected with an error.
+	Env                   []string               `json:"env,omitempty"`                   // A list of global environment variable definitions that will exist for all; build steps in this build. If a variable is defined in both globally and in; a build step, the variable will use the build step value.; ; The elements are of the form "KEY=VALUE" for the environment variable "KEY"; being given the value "VALUE".
+	Logging               *Logging               `json:"logging,omitempty"`               // Option to specify the logging mode, which determines where the logs are; stored.
+	LogStreamingOption    *LogStreamingOption    `json:"logStreamingOption,omitempty"`    // Option to define build log streaming behavior to Google Cloud; Storage.
+	MachineType           *MachineType           `json:"machineType,omitempty"`           // Compute Engine machine type on which to run the build.
+	RequestedVerifyOption *RequestedVerifyOption `json:"requestedVerifyOption,omitempty"` // Requested verifiability options.
+	SecretEnv             []string               `json:"secretEnv,omitempty"`             // A list of global environment variables, which are encrypted using a Cloud; Key Management Service crypto key. These values must be specified in the; build's `Secret`. These variables will be available to all build steps; in this build.
+	SourceProvenanceHash  []SourceProvenanceHash `json:"sourceProvenanceHash,omitempty"`  // Requested hash for SourceProvenance.
+	SubstitutionOption    *SubstitutionOption    `json:"substitutionOption,omitempty"`    // Option to specify behavior when there is an error in the substitution; checks.
+	Volumes               []Volume               `json:"volumes,omitempty"`               // Global list of volumes to mount for ALL build steps; ; Each volume is created as an empty volume prior to starting the build; process. Upon completion of the build, volumes and their contents are; discarded. Global volume names and paths cannot conflict with the volumes; defined a build step.; ; Using a global volume in a build with only one step is not valid as; it is indicative of a build request with an incorrect configuration.
+	WorkerPool            *string                `json:"workerPool,omitempty"`            // Option to specify a `WorkerPool` for the build.; Format: projects/{project}/locations/{location}/workerPools/{workerPool}
 }
 
 // Volume: Volume describes a Docker container volume which is mounted into build steps
@@ -192,7 +192,7 @@ type FileHashValue struct {
 
 // FileHashElement: Container message for hash values.
 type FileHashElement struct {
-	Type  *Type  `json:"type"`            // The type of hash that was performed.
+	Type  *Type  `json:"type,omitempty"`  // The type of hash that was performed.
 	Value []byte `json:"value,omitempty"` // The hash value.
 }
 
@@ -236,7 +236,7 @@ type Step struct {
 	Name       *string      `json:"name,omitempty"`       // The name of the container image that will run this particular; build step.; ; If the image is available in the host's Docker daemon's cache, it; will be run directly. If not, the host will attempt to pull the image; first, using the builder service account's credentials if necessary.; ; The Docker daemon's cache will already have the latest versions of all of; the officially supported build steps; ; ([https://github.com/GoogleCloudPlatform/cloud-builders](https://github.com/GoogleCloudPlatform/cloud-builders)).; The Docker daemon will also have cached many of the layers for some popular; images, like "ubuntu", "debian", but they will be refreshed at the time you; attempt to use them.; ; If you built an image in a previous build step, it will be stored in the; host's Docker daemon's cache and is available to use as the name for a; later build step.
 	PullTiming *PullTiming  `json:"pullTiming,omitempty"` // Stores timing information for pulling this build step's; builder image only.
 	SecretEnv  []string     `json:"secretEnv,omitempty"`  // A list of environment variables which are encrypted using a Cloud Key; Management Service crypto key. These values must be specified in the; build's `Secret`.
-	Status     *Status      `json:"status"`               // Status of the build step. At this time, build step status is; only updated on build completion; step status is not updated in real-time; as the build progresses.
+	Status     *Status      `json:"status,omitempty"`     // Status of the build step. At this time, build step status is; only updated on build completion; step status is not updated in real-time; as the build progresses.
 	Timeout    *StepTimeout `json:"timeout,omitempty"`    // Time limit for executing this build step. If not defined, the step has no; time limit and will be allowed to continue to run until either it completes; or the build itself times out.
 	Timing     *StepTiming  `json:"timing,omitempty"`     // Stores timing information for executing this build step.
 	Volumes    []Volume     `json:"volumes,omitempty"`    // List of volumes to mount into the build step.; ; Each volume is created as an empty volume prior to execution of the; build step. Upon completion of the build, volumes and their contents are; discarded.; ; Using a named volume in only one step is not valid as it is indicative; of a build request with an incorrect configuration.
@@ -288,112 +288,82 @@ type TimeSpan struct {
 	StartTime *string `json:"startTime,omitempty"` // Start of time span.
 }
 
-type LogStreamingOptionEnum string
-
-const (
-	StreamDefault LogStreamingOptionEnum = "STREAM_DEFAULT"
-	StreamOff     LogStreamingOptionEnum = "STREAM_OFF"
-	StreamOn      LogStreamingOptionEnum = "STREAM_ON"
-)
-
-type LoggingEnum string
-
-const (
-	GcsOnly            LoggingEnum = "GCS_ONLY"
-	Legacy             LoggingEnum = "LEGACY"
-	LoggingUnspecified LoggingEnum = "LOGGING_UNSPECIFIED"
-)
-
-type MachineTypeEnum string
-
-const (
-	N1Highcpu32 MachineTypeEnum = "N1_HIGHCPU_32"
-	N1Highcpu8  MachineTypeEnum = "N1_HIGHCPU_8"
-	Unspecified MachineTypeEnum = "UNSPECIFIED"
-)
-
-type RequestedVerifyOptionEnum string
-
-const (
-	NotVerified RequestedVerifyOptionEnum = "NOT_VERIFIED"
-	Verified    RequestedVerifyOptionEnum = "VERIFIED"
-)
-
-type SourceProvenanceHashEnum string
-
-const (
-	Md5    SourceProvenanceHashEnum = "MD5"
-	None   SourceProvenanceHashEnum = "NONE"
-	Sha256 SourceProvenanceHashEnum = "SHA256"
-)
-
-type SubstitutionOptionEnum string
-
-const (
-	AllowLoose SubstitutionOptionEnum = "ALLOW_LOOSE"
-	MustMatch  SubstitutionOptionEnum = "MUST_MATCH"
-)
-
-type StatusEnum string
-
-const (
-	Cancelled     StatusEnum = "CANCELLED"
-	Expired       StatusEnum = "EXPIRED"
-	Failure       StatusEnum = "FAILURE"
-	InternalError StatusEnum = "INTERNAL_ERROR"
-	Queued        StatusEnum = "QUEUED"
-	StatusUnknown StatusEnum = "STATUS_UNKNOWN"
-	Success       StatusEnum = "SUCCESS"
-	Timeout       StatusEnum = "TIMEOUT"
-	Working       StatusEnum = "WORKING"
-)
-
-// LogStreamingOption: Option to define build log streaming behavior to Google Cloud
+// Option to define build log streaming behavior to Google Cloud
 // Storage.
-type LogStreamingOption struct {
-	Enum    *LogStreamingOptionEnum
-	Integer *int64
-}
+type LogStreamingOption string
 
-// Logging: Option to specify the logging mode, which determines where the logs are
+const (
+	StreamDefault LogStreamingOption = "STREAM_DEFAULT"
+	StreamOff     LogStreamingOption = "STREAM_OFF"
+	StreamOn      LogStreamingOption = "STREAM_ON"
+)
+
+// Option to specify the logging mode, which determines where the logs are
 // stored.
-type Logging struct {
-	Enum    *LoggingEnum
-	Integer *int64
-}
+type Logging string
 
-// MachineType: Compute Engine machine type on which to run the build.
-type MachineType struct {
-	Enum    *MachineTypeEnum
-	Integer *int64
-}
+const (
+	GcsOnly            Logging = "GCS_ONLY"
+	Legacy             Logging = "LEGACY"
+	LoggingUnspecified Logging = "LOGGING_UNSPECIFIED"
+)
 
-// RequestedVerifyOption: Requested verifiability options.
-type RequestedVerifyOption struct {
-	Enum    *RequestedVerifyOptionEnum
-	Integer *int64
-}
+// Compute Engine machine type on which to run the build.
+type MachineType string
+
+const (
+	N1Highcpu32 MachineType = "N1_HIGHCPU_32"
+	N1Highcpu8  MachineType = "N1_HIGHCPU_8"
+	Unspecified MachineType = "UNSPECIFIED"
+)
+
+// Requested verifiability options.
+type RequestedVerifyOption string
+
+const (
+	NotVerified RequestedVerifyOption = "NOT_VERIFIED"
+	Verified    RequestedVerifyOption = "VERIFIED"
+)
+
+// The type of hash that was performed.
+type Type string
+
+const (
+	Md5    Type = "MD5"
+	None   Type = "NONE"
+	Sha256 Type = "SHA256"
+)
+
+// Option to specify behavior when there is an error in the substitution
+// checks.
+type SubstitutionOption string
+
+const (
+	AllowLoose SubstitutionOption = "ALLOW_LOOSE"
+	MustMatch  SubstitutionOption = "MUST_MATCH"
+)
+
+// Status of the build.
+//
+// Status of the build step. At this time, build step status is
+// only updated on build completion; step status is not updated in real-time
+// as the build progresses.
+type Status string
+
+const (
+	Cancelled     Status = "CANCELLED"
+	Expired       Status = "EXPIRED"
+	Failure       Status = "FAILURE"
+	InternalError Status = "INTERNAL_ERROR"
+	Queued        Status = "QUEUED"
+	StatusUnknown Status = "STATUS_UNKNOWN"
+	Success       Status = "SUCCESS"
+	Timeout       Status = "TIMEOUT"
+	Working       Status = "WORKING"
+)
 
 type SourceProvenanceHash struct {
 	Double  *float64
-	Enum    *SourceProvenanceHashEnum
-	Integer *int64
-}
-
-// SubstitutionOption: Option to specify behavior when there is an error in the substitution
-// checks.
-type SubstitutionOption struct {
-	Enum    *SubstitutionOptionEnum
-	Integer *int64
-}
-
-// Type: The type of hash that was performed.
-type Type struct {
-	Enum    *SourceProvenanceHashEnum
-	Integer *int64
-}
-
-type Status struct {
-	Enum    *StatusEnum
+	Enum    *Type
 	Integer *int64
 }

--- a/cloud/firestore/v1/document_event_data.go
+++ b/cloud/firestore/v1/document_event_data.go
@@ -18,7 +18,7 @@ package firestore
 type DocumentEventData struct {
 	OldValue   *OldValue   `json:"oldValue,omitempty"`   // A Document object containing a pre-operation document snapshot.; This is only populated for update and delete events.
 	UpdateMask *UpdateMask `json:"updateMask,omitempty"` // A DocumentMask object that lists changed fields.; This is only populated for update events.
-	Value      *Value      `json:"value,omitempty"`      // A Document object containing a post-operation document snapshot.; This is not populated for delete events. (TODO: check this!)
+	Value      *Value      `json:"value,omitempty"`      // A Document object containing a post-operation document snapshot.; This is not populated for delete events.
 }
 
 // OldValue: A Document object containing a pre-operation document snapshot.
@@ -34,32 +34,32 @@ type OldValue struct {
 
 // OldValueField: A message that can hold any of the supported value types.
 type OldValueField struct {
-	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
-	BooleanValue   *bool           `json:"booleanValue,omitempty"`        // A boolean value.
-	BytesValue     []byte          `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
-	DoubleValue    *float64        `json:"doubleValue,omitempty"`         // A double value.
-	GeoPointValue  *GeoPointValue  `json:"geoPointValue,omitempty"`       // A geo point value representing a point on the surface of Earth.
-	IntegerValue   *int64          `json:"integerValue,string,omitempty"` // An integer value.
-	MapValue       *MapValue       `json:"mapValue,omitempty"`            // A map value.
-	NullValue      *NullValueUnion `json:"nullValue"`                     // A null value.
-	ReferenceValue *string         `json:"referenceValue,omitempty"`      // A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-	StringValue    *string         `json:"stringValue,omitempty"`         // A string value.; ; The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes of the UTF-8 representation are considered by; queries.
-	TimestampValue *string         `json:"timestampValue,omitempty"`      // A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
+	ArrayValue     *ArrayValue    `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
+	BooleanValue   *bool          `json:"booleanValue,omitempty"`        // A boolean value.
+	BytesValue     []byte         `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
+	DoubleValue    *float64       `json:"doubleValue,omitempty"`         // A double value.
+	GeoPointValue  *GeoPointValue `json:"geoPointValue,omitempty"`       // A geo point value representing a point on the surface of Earth.
+	IntegerValue   *int64         `json:"integerValue,string,omitempty"` // An integer value.
+	MapValue       *MapValue      `json:"mapValue,omitempty"`            // A map value.
+	NullValue      *NullValueEnum `json:"nullValue,omitempty"`           // A null value.
+	ReferenceValue *string        `json:"referenceValue,omitempty"`      // A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+	StringValue    *string        `json:"stringValue,omitempty"`         // A string value.; ; The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes of the UTF-8 representation are considered by; queries.
+	TimestampValue *string        `json:"timestampValue,omitempty"`      // A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
 }
 
 // MapValueField: A message that can hold any of the supported value types.
 type MapValueField struct {
-	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
-	BooleanValue   *bool           `json:"booleanValue,omitempty"`        // A boolean value.
-	BytesValue     []byte          `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
-	DoubleValue    *float64        `json:"doubleValue,omitempty"`         // A double value.
-	GeoPointValue  *GeoPointValue  `json:"geoPointValue,omitempty"`       // A geo point value representing a point on the surface of Earth.
-	IntegerValue   *int64          `json:"integerValue,string,omitempty"` // An integer value.
-	MapValue       *MapValue       `json:"mapValue,omitempty"`            // A map value.
-	NullValue      *NullValueUnion `json:"nullValue"`                     // A null value.
-	ReferenceValue *string         `json:"referenceValue,omitempty"`      // A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-	StringValue    *string         `json:"stringValue,omitempty"`         // A string value.; ; The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes of the UTF-8 representation are considered by; queries.
-	TimestampValue *string         `json:"timestampValue,omitempty"`      // A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
+	ArrayValue     *ArrayValue    `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
+	BooleanValue   *bool          `json:"booleanValue,omitempty"`        // A boolean value.
+	BytesValue     []byte         `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
+	DoubleValue    *float64       `json:"doubleValue,omitempty"`         // A double value.
+	GeoPointValue  *GeoPointValue `json:"geoPointValue,omitempty"`       // A geo point value representing a point on the surface of Earth.
+	IntegerValue   *int64         `json:"integerValue,string,omitempty"` // An integer value.
+	MapValue       *MapValue      `json:"mapValue,omitempty"`            // A map value.
+	NullValue      *NullValueEnum `json:"nullValue,omitempty"`           // A null value.
+	ReferenceValue *string        `json:"referenceValue,omitempty"`      // A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+	StringValue    *string        `json:"stringValue,omitempty"`         // A string value.; ; The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes of the UTF-8 representation are considered by; queries.
+	TimestampValue *string        `json:"timestampValue,omitempty"`      // A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
 }
 
 // MapValue: A map value.
@@ -69,17 +69,17 @@ type MapValue struct {
 
 // ValueElement: A message that can hold any of the supported value types.
 type ValueElement struct {
-	ArrayValue     *ArrayValue     `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
-	BooleanValue   *bool           `json:"booleanValue,omitempty"`        // A boolean value.
-	BytesValue     []byte          `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
-	DoubleValue    *float64        `json:"doubleValue,omitempty"`         // A double value.
-	GeoPointValue  *GeoPointValue  `json:"geoPointValue,omitempty"`       // A geo point value representing a point on the surface of Earth.
-	IntegerValue   *int64          `json:"integerValue,string,omitempty"` // An integer value.
-	MapValue       *MapValue       `json:"mapValue,omitempty"`            // A map value.
-	NullValue      *NullValueUnion `json:"nullValue"`                     // A null value.
-	ReferenceValue *string         `json:"referenceValue,omitempty"`      // A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-	StringValue    *string         `json:"stringValue,omitempty"`         // A string value.; ; The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes of the UTF-8 representation are considered by; queries.
-	TimestampValue *string         `json:"timestampValue,omitempty"`      // A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
+	ArrayValue     *ArrayValue    `json:"arrayValue,omitempty"`          // An array value.; ; Cannot directly contain another array value, though can contain an; map which contains another array.
+	BooleanValue   *bool          `json:"booleanValue,omitempty"`        // A boolean value.
+	BytesValue     []byte         `json:"bytesValue,omitempty"`          // A bytes value.; ; Must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes are considered by queries.
+	DoubleValue    *float64       `json:"doubleValue,omitempty"`         // A double value.
+	GeoPointValue  *GeoPointValue `json:"geoPointValue,omitempty"`       // A geo point value representing a point on the surface of Earth.
+	IntegerValue   *int64         `json:"integerValue,string,omitempty"` // An integer value.
+	MapValue       *MapValue      `json:"mapValue,omitempty"`            // A map value.
+	NullValue      *NullValueEnum `json:"nullValue,omitempty"`           // A null value.
+	ReferenceValue *string        `json:"referenceValue,omitempty"`      // A reference to a document. For example:; `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+	StringValue    *string        `json:"stringValue,omitempty"`         // A string value.; ; The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.; Only the first 1,500 bytes of the UTF-8 representation are considered by; queries.
+	TimestampValue *string        `json:"timestampValue,omitempty"`      // A timestamp value.; ; Precise only to microseconds. When stored, any additional precision is; rounded down.
 }
 
 // ArrayValue: An array value.
@@ -103,7 +103,7 @@ type UpdateMask struct {
 }
 
 // Value: A Document object containing a post-operation document snapshot.
-// This is not populated for delete events. (TODO: check this!)
+// This is not populated for delete events.
 //
 // A Document object containing a pre-operation document snapshot.
 // This is only populated for update and delete events.
@@ -116,14 +116,9 @@ type Value struct {
 	UpdateTime *string                  `json:"updateTime,omitempty"` // The time at which the document was last changed.; ; This value is initially set to the `create_time` then increases; monotonically with each change to the document. It can also be; compared to values from other documents and the `read_time` of a query.
 }
 
-type CreateTime string
+// A null value.
+type NullValueEnum string
 
 const (
-	NullValue CreateTime = "NULL_VALUE"
+	NullValue NullValueEnum = "NULL_VALUE"
 )
-
-// NullValueUnion: A null value.
-type NullValueUnion struct {
-	Enum    *CreateTime
-	Integer *int64
-}

--- a/cloud/pubsub/v1/message_published_data.go
+++ b/cloud/pubsub/v1/message_published_data.go
@@ -25,5 +25,6 @@ type Message struct {
 	Attributes  map[string]string `json:"attributes,omitempty"`  // Attributes for this message.
 	Data        []byte            `json:"data,omitempty"`        // The binary data in the message.
 	MessageID   *string           `json:"messageId,omitempty"`   // ID of this message, assigned by the server when the message is published.; Guaranteed to be unique within the topic.
+	OrderingKey *string           `json:"orderingKey,omitempty"` // If non-empty, identifies related messages for which publish order should be; respected.
 	PublishTime *string           `json:"publishTime,omitempty"` // The time at which the message was published, populated by the server when; it receives the `Publish` call.
 }

--- a/firebase/remoteconfig/v1/remote_config_event_data.go
+++ b/firebase/remoteconfig/v1/remote_config_event_data.go
@@ -18,9 +18,9 @@ package remoteconfig
 type RemoteConfigEventData struct {
 	Description    *string       `json:"description,omitempty"`           // The user-provided description of the corresponding Remote Config template.
 	RollbackSource *int64        `json:"rollbackSource,string,omitempty"` // Only present if this version is the result of a rollback, and will be the; version number of the Remote Config template that was rolled-back to.
-	UpdateOrigin   *UpdateOrigin `json:"updateOrigin"`                    // Where the update action originated.
+	UpdateOrigin   *UpdateOrigin `json:"updateOrigin,omitempty"`          // Where the update action originated.
 	UpdateTime     *string       `json:"updateTime,omitempty"`            // When the Remote Config template was written to the Remote Config server.
-	UpdateType     *UpdateType   `json:"updateType"`                      // What type of update was made.
+	UpdateType     *UpdateType   `json:"updateType,omitempty"`            // What type of update was made.
 	UpdateUser     *UpdateUser   `json:"updateUser,omitempty"`            // Aggregation of all metadata fields about the account that performed the; update.
 	VersionNumber  *int64        `json:"versionNumber,string,omitempty"`  // The version number of the version's corresponding Remote Config template.
 }
@@ -33,32 +33,22 @@ type UpdateUser struct {
 	Name     *string `json:"name,omitempty"`     // Display name.
 }
 
-type UpdateOriginEnum string
+// Where the update action originated.
+type UpdateOrigin string
 
 const (
-	AdminSDKNode                        UpdateOriginEnum = "ADMIN_SDK_NODE"
-	Console                             UpdateOriginEnum = "CONSOLE"
-	RESTAPI                             UpdateOriginEnum = "REST_API"
-	RemoteConfigUpdateOriginUnspecified UpdateOriginEnum = "REMOTE_CONFIG_UPDATE_ORIGIN_UNSPECIFIED"
+	AdminSDKNode                        UpdateOrigin = "ADMIN_SDK_NODE"
+	Console                             UpdateOrigin = "CONSOLE"
+	RESTAPI                             UpdateOrigin = "REST_API"
+	RemoteConfigUpdateOriginUnspecified UpdateOrigin = "REMOTE_CONFIG_UPDATE_ORIGIN_UNSPECIFIED"
 )
 
-type UpdateTypeEnum string
+// What type of update was made.
+type UpdateType string
 
 const (
-	ForcedUpdate                      UpdateTypeEnum = "FORCED_UPDATE"
-	IncrementalUpdate                 UpdateTypeEnum = "INCREMENTAL_UPDATE"
-	RemoteConfigUpdateTypeUnspecified UpdateTypeEnum = "REMOTE_CONFIG_UPDATE_TYPE_UNSPECIFIED"
-	Rollback                          UpdateTypeEnum = "ROLLBACK"
+	ForcedUpdate                      UpdateType = "FORCED_UPDATE"
+	IncrementalUpdate                 UpdateType = "INCREMENTAL_UPDATE"
+	RemoteConfigUpdateTypeUnspecified UpdateType = "REMOTE_CONFIG_UPDATE_TYPE_UNSPECIFIED"
+	Rollback                          UpdateType = "ROLLBACK"
 )
-
-// UpdateOrigin: Where the update action originated.
-type UpdateOrigin struct {
-	Enum    *UpdateOriginEnum
-	Integer *int64
-}
-
-// UpdateType: What type of update was made.
-type UpdateType struct {
-	Enum    *UpdateTypeEnum
-	Integer *int64
-}

--- a/tools/gen.sh
+++ b/tools/gen.sh
@@ -5,10 +5,14 @@ echo "Generating the Google Events Library..."
 
 ROOT=$(dirname $PWD)
 
+find cloud -type f ! -name '*_test.go' -delete
+find firebase -type f ! -name '*_test.go' -delete
+
 # Generate new types
 qt \
 --in=$ROOT/google-cloudevents/jsonschema \
 --out=$PWD \
+--enum-as-string=true \
 --l=golang
 
 # Move generated library into correct directory


### PR DESCRIPTION
Parses enums (sent as strings) to strings by generating the client 

- Adds "enum support" to feature list
- Includes test for parsing the protoPayload of a CAL event

See this conversation for more details about implementation: https://github.com/googleapis/google-cloudevents-go/issues/68#issuecomment-854056635

Fixes: https://github.com/googleapis/google-cloudevents-go/issues/68
Requires upstream qt feature: https://github.com/googleapis/google-cloudevents/pull/244