### PR TITLE
testing: add code generator automation

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
         rev=$(git rev-parse --short HEAD)
         echo "::set-output name=revision::$rev"
-      working-directory: env.GENERATE_DATA_SOURCE
+      working-directory: $${ env.GENERATE_DATA_SOURCE }
 
     - name: Create a pull request with updates
       # https://github.com/googleapis/code-suggester#Action

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -22,8 +22,8 @@ name: Generate Library & Open Pull Request
 
 on:
   schedule:
-    # Run at the end of every day.
-    - cron: 0 0 * * *
+    # Run at the end of every day. (10:10pm)
+    - cron: 10 22 * * *
   workflow_dispatch:
 
 jobs:
@@ -37,10 +37,10 @@ jobs:
       GENERATE_DATA_SOURCE: protos/google-cloudevents
 
     steps:
-    - name: Checkout this repository
+    - name: Go Library > Checkout Repository
       uses: actions/checkout@v3
 
-    - name: Checkout data repository
+    - name: Proto Schemas > Checkout Repository
       uses: actions/checkout@v3
       with:
         repository: googleapis/google-cloudevents

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -31,7 +31,7 @@ jobs:
   create_pr:
     runs-on: ubuntu-latest
     env:
-      GENERATE_DATA_SOURCE: tmp/google-cloudevents
+      GENERATE_DATA_SOURCE: protos/google-cloudevents
 
     steps:
     - name: Checkout this repository

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -17,7 +17,7 @@ name: Generate Go Library and Open Pull Request
 # Uses protos from HEAD of https://github.com/googleapis/google-cloudevents
 # and tooling from HEAD of this repository to update all generated code.
 #
-# It creates a PR whose branch will include an unmodified snapshot of the
+# Creates a PR whose branch will include an unmodified snapshot of the
 # tooling used to generate changes.
 
 on:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: googleapis/google-cloudevents
-        path: env.GENERATE_DATA_SOURCE
+        path: ${{ env.GENERATE_DATA_SOURCE }}
 
     - name: Setup Go
       uses: actions/setup-go@v3
@@ -50,11 +50,11 @@ jobs:
 
     - name: Install the generator
       run: |
-        sh tools/setup-generator.sh
+        bash tools/setup-generator.sh
 
     - name: Run the generator
       run: |
-        sh ./generate-code.sh
+        bash ./generate-code.sh
       env:
         GENERATE_PROTOC_PATH: tmp/protobuf/bin/protoc
     

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,106 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Generate Go Library and Open Pull Request
+
+# Uses protos from HEAD of https://github.com/googleapis/google-cloudevents
+# and tooling from HEAD of this repository to update all generated code.
+#
+# It creates a PR whose branch will include an unmodified snapshot of the
+# tooling used to generate changes.
+
+on:
+  schedule:
+    # Run at the end of every day.
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+jobs:
+  # Create a pull request.
+  create_pr:
+    runs-on: ubuntu-latest
+    env:
+      GENERATE_DATA_SOURCE: tmp/google-cloudevents
+
+    steps:
+    - name: Checkout this repository
+      uses: actions/checkout@v3
+
+    - name: Checkout data repository
+      uses: actions/checkout@v3
+      with:
+        repository: googleapis/google-cloudevents
+        path: env.GENERATE_DATA_SOURCE
+
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19.x
+
+    - name: Install the generator
+      run: |
+        sh tools/setup-generator.sh
+
+    - name: Run the generator
+      run: |
+        sh ./generate-code.sh
+      env:
+        GENERATE_PROTOC_PATH: tmp/protobuf/bin/protoc
+    
+    # This step identifies the github revision of the data source repository.
+    # This is used to create a detailed Pull Request description.
+    - name: Source Version
+      id: source-version
+      run: |
+        rev=$(git rev-parse --short HEAD)
+        echo "::set-output name=revision::$rev"
+      working-directory: env.GENERATE_DATA_SOURCE
+
+    - name: Create a pull request with updates
+      # https://github.com/googleapis/code-suggester#Action
+      uses: googleapis/code-suggester@v4
+      env:
+        # Provided by the GitHub Automation team
+        ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+      with:
+        command: pr
+        upstream_owner: ${{ github.repository_owner }}
+        upstream_repo: 'google-cloudevents-go'
+
+        # Pull Request Title
+        title: 'feat: Run the code generator'
+        # Commit Message
+        message: 'feat: Run the code generator (${{ steps.source-version.outputs.revision }})'
+        description: |
+          :robot: Auto-generated Pull Request.
+
+          This PR was created from a recent update in the [google-cloudevents](https://github.com/googleapis/google-cloudevents) repository.
+          Specifically, the change at https://github.com/googleapis/google-cloudevents/commit/${{ steps.source-version.outputs.revision }}.
+
+          Future updates to the protos in that repository made before this PR is
+          merged will lead to a force push update of this Pull Request with
+          the latest changes.
+
+          * **Generator configuration:** https://github.com/${{ github.repository }}/blob/${{ steps.source-version.outputs.revision }}/.github/workflows/generate.yml'
+          * **Generator Setup Script:** https://github.com/${{ github.repository }}/blob/${{ github.sha }}/tools/setup-generator.sh'
+          * **Generator script:** https://github.com/${{ github.repository }}/blob/${{ github.sha }}/generate-code.sh'
+
+        # A static branch name and force pushes are meant to create
+        # a single open PR with all pending updates.
+        branch: 'generator'
+        force: true
+
+        fork: true # action automatically forks repo
+        git_dir: '.'
+        primary: 'main'

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -30,6 +30,9 @@ jobs:
   # Create a pull request.
   create_pr:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: true
     env:
       GENERATE_DATA_SOURCE: protos/google-cloudevents
 

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Generate Go Library and Open Pull Request
+name: Generate Library & Open Pull Request
 
 # Uses protos from HEAD of https://github.com/googleapis/google-cloudevents
 # and tooling from HEAD of this repository to update all generated code.
@@ -28,7 +28,7 @@ on:
 
 jobs:
   # Create a pull request.
-  create_pr:
+  create-pr:
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -55,6 +55,8 @@ jobs:
 
     - name: Run the generator
       run: |
+        # Spoke to soon.
+        ls -l tmp
         bash ./generate-code.sh
       env:
         GENERATE_PROTOC_PATH: tmp/protobuf/bin/protoc

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: googleapis/google-cloudevents
-        path: env.GENERATE_DATA_SOURCE
+        path: ${{ env.GENERATE_DATA_SOURCE }}
 
     - name: Setup Go
       uses: actions/setup-go@v3
@@ -52,11 +52,9 @@ jobs:
     - name: Install the generator
       run: |
         bash tools/setup-generator.sh
-      shell: bash
 
     - name: Run the generator
       run: |
         bash ./generate-code.sh
-      shell: bash
       env:
         GENERATE_PROTOC_PATH: tmp/protobuf/bin/protoc

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -55,6 +55,8 @@ jobs:
 
     - name: Run the generator
       run: |
+        # What's all this then?
+        ls -l
         bash ./generate-code.sh
       env:
         GENERATE_PROTOC_PATH: tmp/protobuf/bin/protoc

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Test Go Library Generation
+name: Test Library Generation
 
 # Uses protos from HEAD of https://github.com/googleapis/google-cloudevents
 # and tooling from HEAD of this repository to update all generated code.
@@ -29,7 +29,7 @@ on:
 
 jobs:
   # Create a pull request.
-  create_pr:
+  test-generator:
     runs-on: ubuntu-latest
     env:
       GENERATE_DATA_SOURCE: protos/google-cloudevents

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -32,7 +32,7 @@ jobs:
   create_pr:
     runs-on: ubuntu-latest
     env:
-      GENERATE_DATA_SOURCE: tmp/google-cloudevents
+      GENERATE_DATA_SOURCE: protos/google-cloudevents
 
     steps:
     - name: Checkout this repository
@@ -55,8 +55,6 @@ jobs:
 
     - name: Run the generator
       run: |
-        # Spoke to soon.
-        ls -l tmp
         bash ./generate-code.sh
       env:
         GENERATE_PROTOC_PATH: tmp/protobuf/bin/protoc

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -25,6 +25,7 @@ on:
     paths:
       - 'tools/**'
       - 'generate-code.sh'
+      - '.github/workflows/test-generator.yml'
 
 jobs:
   # Create a pull request.

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -17,8 +17,8 @@ name: Test Library Generation
 # Uses protos from HEAD of https://github.com/googleapis/google-cloudevents
 # and tooling from HEAD of this repository to update all generated code.
 #
-# It creates a PR whose branch will include an unmodified snapshot of the
-# tooling used to generate changes.
+# If the generator process fails, the workflow will fail showing the toolchain
+# update in the Pull Request is not ready to merge.
 
 on:
   pull_request:

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -55,8 +55,6 @@ jobs:
 
     - name: Run the generator
       run: |
-        # What's all this then?
-        ls -l
         bash ./generate-code.sh
       env:
         GENERATE_PROTOC_PATH: tmp/protobuf/bin/protoc

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -51,12 +51,12 @@ jobs:
 
     - name: Install the generator
       run: |
-        tools/setup-generator.sh
+        bash tools/setup-generator.sh
       shell: bash
 
     - name: Run the generator
       run: |
-        ./generate-code.sh
+        bash ./generate-code.sh
       shell: bash
       env:
         GENERATE_PROTOC_PATH: tmp/protobuf/bin/protoc

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -51,10 +51,12 @@ jobs:
 
     - name: Install the generator
       run: |
-        sh tools/setup-generator.sh
+        tools/setup-generator.sh
+      shell: bash
 
     - name: Run the generator
       run: |
-        sh ./generate-code.sh
+        ./generate-code.sh
+      shell: bash
       env:
         GENERATE_PROTOC_PATH: tmp/protobuf/bin/protoc

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -35,10 +35,10 @@ jobs:
       GENERATE_DATA_SOURCE: protos/google-cloudevents
 
     steps:
-    - name: Checkout this repository
+    - name: Go Library > Checkout Repository
       uses: actions/checkout@v3
     
-    - name: Checkout data repository
+    - name: Proto Schemas > Checkout Repository
       uses: actions/checkout@v3
       with:
         repository: googleapis/google-cloudevents

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -1,0 +1,59 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test Go Library Generation
+
+# Uses protos from HEAD of https://github.com/googleapis/google-cloudevents
+# and tooling from HEAD of this repository to update all generated code.
+#
+# It creates a PR whose branch will include an unmodified snapshot of the
+# tooling used to generate changes.
+
+on:
+  pull_request:
+    paths:
+      - 'tools/**'
+      - 'generate-code.sh'
+
+jobs:
+  # Create a pull request.
+  create_pr:
+    runs-on: ubuntu-latest
+    env:
+      GENERATE_DATA_SOURCE: tmp/google-cloudevents
+
+    steps:
+    - name: Checkout this repository
+      uses: actions/checkout@v3
+    
+    - name: Checkout data repository
+      uses: actions/checkout@v3
+      with:
+        repository: googleapis/google-cloudevents
+        path: env.GENERATE_DATA_SOURCE
+
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19.x
+
+    - name: Install the generator
+      run: |
+        sh tools/setup-generator.sh
+
+    - name: Run the generator
+      run: |
+        sh ./generate-code.sh
+      env:
+        GENERATE_PROTOC_PATH: tmp/protobuf/bin/protoc

--- a/generate-code.sh
+++ b/generate-code.sh
@@ -53,6 +53,8 @@ if [[ -z "${GENERATE_PROTOC_PATH}" ]]; then
   exit 1
 fi
 
+GENERATE_DATA_SOURCE=$(realpath "${GENERATE_DATA_SOURCE}")
+
 # Derive proto repo metadata.
 data_version=$(git -C "${GENERATE_DATA_SOURCE}" rev-parse --short HEAD)
 data_date=$(git -C "${GENERATE_DATA_SOURCE}" show -s --format=%ci "${data_version}")

--- a/generate-code.sh
+++ b/generate-code.sh
@@ -32,7 +32,7 @@ _heading() {
     echo
     echo "$(tput bold)${1}$(tput sgr0)"
   else
-    echo " -> ${1}"
+    echo "=> ${1}"
   fi
 }
 

--- a/generate-code.sh
+++ b/generate-code.sh
@@ -32,7 +32,7 @@ _heading() {
     echo
     echo "$(tput bold)${1}$(tput sgr0)"
   else
-    echo "${1}"
+    echo " -> ${1}"
   fi
 }
 

--- a/generate-code.sh
+++ b/generate-code.sh
@@ -36,6 +36,7 @@ name=$(basename "${BASH_SOURCE[0]}")
 library_version=$(git rev-parse --short HEAD)
 library_date=$(git show -s --format=%ci "${library_version}")
 echo "google-cloudevents-go > ${name} (${library_version} on ${library_date})"
+echo "working-directory: ${PWD}"
 
 # Required configuration.
 if [[ -z "${GENERATE_DATA_SOURCE}" ]]; then

--- a/generate-code.sh
+++ b/generate-code.sh
@@ -28,8 +28,12 @@ set -e
 
 # Output Utilities
 _heading() {
-  echo
-  echo "$(tput bold)${1}$(tput sgr0)"
+  if [ -t 1 ];  then
+    echo
+    echo "$(tput bold)${1}$(tput sgr0)"
+  else
+    echo "${1}"
+  fi
 }
 
 name=$(basename "${BASH_SOURCE[0]}")

--- a/tools/setup-generator.sh
+++ b/tools/setup-generator.sh
@@ -22,6 +22,7 @@ name=$(basename ${BASH_SOURCE:-$0})
 library_version=$(git rev-parse --short HEAD)
 library_date=$(git show -s --format=%ci "${library_version}")
 echo "google-cloudevents-go > ${name} (${library_version} on ${library_date})"
+echo "working-directory: ${PWD}"
 echo
 
 # Create a location for local tool installation.

--- a/tools/setup-generator.sh
+++ b/tools/setup-generator.sh
@@ -16,7 +16,7 @@
 # Setup environment for code generation:
 # - install protobuf tools in a local temp directory
 # - clone google-cloudevents repo if needed
-set -eu
+set -e
 
 name=$(basename ${BASH_SOURCE:-$0})
 library_version=$(git rev-parse --short HEAD)
@@ -24,6 +24,11 @@ library_date=$(git show -s --format=%ci "${library_version}")
 echo "google-cloudevents-go > ${name} (${library_version} on ${library_date})"
 echo "working-directory: ${PWD}"
 echo
+
+if [ "${GENERATE_DATA_SOURCE:0:3}" = "tmp" ] || [ "${GENERATE_DATA_SOURCE:0:5}" = "./tmp"]; then
+  echo "setup-generator.sh will delete all contents of ./tmp. Currently GENERATE_DATA_SOURCE='${GENERATE_DATA_SOURCE}'."
+  exit 2
+fi
 
 # Create a location for local tool installation.
 echo "- Removing existing tmp/ directory"

--- a/tools/setup-generator.sh
+++ b/tools/setup-generator.sh
@@ -16,9 +16,9 @@
 # Setup environment for code generation:
 # - install protobuf tools in a local temp directory
 # - clone google-cloudevents repo if needed
-set -e
+set -eu
 
-name=$(basename $BASH_SOURCE)
+name=$(basename ${BASH_SOURCE:-$0})
 library_version=$(git rev-parse --short HEAD)
 library_date=$(git show -s --format=%ci "${library_version}")
 echo "google-cloudevents-go > ${name} (${library_version} on ${library_date})"


### PR DESCRIPTION
This PR adds Code Generation, and testing of the Code Generation. This is the GitHub Actions automation piece that builds on the shell scripts previously merged in #115

This PR introduces two new GitHub Workflows:
* test-generator.yml runs the code generation process as a PR check.
* generate.yml runs the code generation process as a nightly or manual job, opening a PR with updates. It is intended that a single PR be opened at a time.

Additional updates:
* tools/setup-generator.sh fails if `GENERATE_DATA_SOURCE`  is pre-configured to be inside `tmp/`
* generate-code.sh gains no-TTY support for the heading formatter

End-to-end testing: This PR is it's own test for the test-generator.yml workflow. The generator.yml workflow has not been tested but once merged manual trigger can be used to test and refine in a follow-up PR.