### PR TITLE
fix(generator): github action source-version syntax error

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
         rev=$(git rev-parse --short HEAD)
         echo "::set-output name=revision::$rev"
-      working-directory: $${ env.GENERATE_DATA_SOURCE }
+      working-directory: ${{ env.GENERATE_DATA_SOURCE }}
 
     - name: Create a pull request with updates
       # https://github.com/googleapis/code-suggester#Action


### PR DESCRIPTION
Botched syntax to specify the path to the google-cloudevents repository in the generator.yml workflow.

Failure Example: https://github.com/googleapis/google-cloudevents-go/actions/runs/3208126072/jobs/5243700858