### PR TITLE
fix(generator): use side-by-side repositories

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -33,12 +33,17 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: true
+    defaults:
+      run:
+        working-directory: library
     env:
-      GENERATE_DATA_SOURCE: protos/google-cloudevents
+      GENERATE_DATA_SOURCE: ../protos/google-cloudevents
 
     steps:
     - name: Go Library > Checkout Repository
       uses: actions/checkout@v3
+      with:
+        path: library
 
     - name: Proto Schemas > Checkout Repository
       uses: actions/checkout@v3

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -37,7 +37,7 @@ jobs:
       run:
         working-directory: library
     env:
-      GENERATE_DATA_SOURCE: ../protos/google-cloudevents
+      GENERATE_DATA_SOURCE: protos/google-cloudevents
 
     steps:
     - name: Go Library > Checkout Repository

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -37,11 +37,10 @@ jobs:
       run:
         working-directory: library # sync with env.LIBRARY_CHECKOUT_PATH
     env:
-      # Using a side-by-side checkout approach, but need
-      # to run scripts from inside the library repository.
-      DATA_SOURCE_CHECKOUT_PATH: protos-source-repo
+      # Library & Data Source repos using side-by-side checkout.
       LIBRARY_CHECKOUT_PATH: library # sync with defaults.run.working-directory
-      GENERATE_DATA_SOURCE: ../protos-source-repo
+      DATA_SOURCE_CHECKOUT_PATH: protos-source-repo
+      GENERATE_DATA_SOURCE: ../protos-source-repo # data relative to library working directory
 
     steps:
     - name: Go Library > Checkout Repository

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -37,7 +37,10 @@ jobs:
       run:
         working-directory: library
     env:
-      GENERATE_DATA_SOURCE: protos/google-cloudevents
+      # Using a side-by-side checkout approach, but need
+      # to run scripts from inside the library repository.
+      DATA_SOURCE_CHECKOUT_PATH: protos-source-repo
+      GENERATE_DATA_SOURCE: ../protos-source-repo
 
     steps:
     - name: Go Library > Checkout Repository
@@ -49,7 +52,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: googleapis/google-cloudevents
-        path: ${{ env.GENERATE_DATA_SOURCE }}
+        path: ${{ env.DATA_SOURCE_CHECKOUT_PATH }}
 
     - name: Setup Go
       uses: actions/setup-go@v3

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -35,18 +35,19 @@ jobs:
       cancel-in-progress: true
     defaults:
       run:
-        working-directory: library
+        working-directory: library # sync with env.LIBRARY_CHECKOUT_PATH
     env:
       # Using a side-by-side checkout approach, but need
       # to run scripts from inside the library repository.
       DATA_SOURCE_CHECKOUT_PATH: protos-source-repo
+      LIBRARY_CHECKOUT_PATH: library # sync with defaults.run.working-directory
       GENERATE_DATA_SOURCE: ../protos-source-repo
 
     steps:
     - name: Go Library > Checkout Repository
       uses: actions/checkout@v3
       with:
-        path: library
+        path: ${{ env.LIBRARY_CHECKOUT_PATH }}
 
     - name: Proto Schemas > Checkout Repository
       uses: actions/checkout@v3
@@ -76,7 +77,7 @@ jobs:
       run: |
         rev=$(git rev-parse --short HEAD)
         echo "::set-output name=revision::$rev"
-      working-directory: ${{ env.GENERATE_DATA_SOURCE }}
+      working-directory: ${{ env.DATA_SOURCE_CHECKOUT_PATH }}
 
     - name: Create a pull request with updates
       # https://github.com/googleapis/code-suggester#Action
@@ -113,5 +114,5 @@ jobs:
         force: true
 
         fork: true # action automatically forks repo
-        git_dir: '.'
+        git_dir: ${{ env.LIBRARY_CHECKOUT_PATH }}
         primary: 'main'

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -33,16 +33,18 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: library
+        working-directory: library # sync with env.LIBRARY_CHECKOUT_PATH
     env:
+      # Library & Data Source repos using side-by-side checkout.
+      LIBRARY_CHECKOUT_PATH: library # sync with defaults.run.working-directory
       DATA_SOURCE_CHECKOUT_PATH: protos-source-repo
-      GENERATE_DATA_SOURCE: ../protos-source-repo
+      GENERATE_DATA_SOURCE: ../protos-source-repo # data relative to library working directory
 
     steps:
     - name: Go Library > Checkout Repository
       uses: actions/checkout@v3
       with:
-        path: library
+        path: ${{ env.LIBRARY_CHECKOUT_PATH }}
     
     - name: Proto Schemas > Checkout Repository
       uses: actions/checkout@v3

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -35,7 +35,8 @@ jobs:
       run:
         working-directory: library
     env:
-      GENERATE_DATA_SOURCE: protos/google-cloudevents
+      DATA_SOURCE_CHECKOUT_PATH: protos-source-repo
+      GENERATE_DATA_SOURCE: ../protos-source-repo
 
     steps:
     - name: Go Library > Checkout Repository
@@ -47,7 +48,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: googleapis/google-cloudevents
-        path: ${{ env.GENERATE_DATA_SOURCE }}
+        path: ${{ env.DATA_SOURCE_CHECKOUT_PATH }}
 
     - name: Setup Go
       uses: actions/setup-go@v3

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -31,12 +31,17 @@ jobs:
   # Create a pull request.
   test-generator:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: library
     env:
       GENERATE_DATA_SOURCE: protos/google-cloudevents
 
     steps:
     - name: Go Library > Checkout Repository
       uses: actions/checkout@v3
+      with:
+        path: library
     
     - name: Proto Schemas > Checkout Repository
       uses: actions/checkout@v3


### PR DESCRIPTION
A series of small adjustments to the GitHub Workflows so the generator will work on manual dispatch.

The primary changes in this PR:
* google-cloudevents and google-cloudevents-go checked out to sibling directories
* Tweaks to how working directory is configured in various steps to account for that