### PR TITLE
fix: skip unsupported pubsub event type

### DIFF
--- a/generate-code.sh
+++ b/generate-code.sh
@@ -111,6 +111,13 @@ _generateData() {
       version=""
     fi
 
+    # Skip unsupported products.
+    if [[ "${product}" == "pubsub" ]]; then
+      echo "- ${product}: skipping generation, not currently supported"
+      return
+    fi
+
+
     echo "- ${product}: ${proto_src} => ${code_dest}data${version}"
 
     $GENERATE_PROTOC_PATH --go_out=. \


### PR DESCRIPTION
The Pub/Sub event type is incompatible with protojson parsing. For now, skip code generation.