### PR TITLE
testing: Fix GHA security and non-generator testing

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -30,6 +30,10 @@ jobs:
   # Create a pull request.
   create-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: true

--- a/.github/workflows/test-generator-fallback.yml
+++ b/.github/workflows/test-generator-fallback.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/test-generator-fallback.yml
+++ b/.github/workflows/test-generator-fallback.yml
@@ -1,0 +1,37 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test Library Generation > Fallback
+
+# This workflow defines fallback handling for required 'test-generator' check.
+# This workflow defines a no-op check so PRs without build impact will be passed.
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+on:
+  pull_request:
+    # Sync with test-generator.yml on.pull_request.paths
+    paths-ignore:
+      - 'tools/**'
+      - 'generate-code.sh'
+      - 'internal/**'
+      - '.github/workflows/test-generator.yml'
+
+jobs:
+  test-generator:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: none
+
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -15,13 +15,15 @@
 name: Test Library Generation
 
 # Uses protos from HEAD of https://github.com/googleapis/google-cloudevents
-# and tooling from HEAD of this repository to update all generated code.
+# and tooling from the current branch to check library generation.
 #
-# If the generator process fails, the workflow will fail showing the toolchain
-# update in the Pull Request is not ready to merge.
+# If the generator fails, the check will fail. If the generator succeeds
+# tests will run to establish changes in the tooling, event schemas, and testdata
+# have not fallen out of sync.
 
 on:
   pull_request:
+    # Sync with test-generator-fallback.yml on.pull_request.paths-ignore
     paths:
       - 'tools/**'
       - 'generate-code.sh'
@@ -29,9 +31,14 @@ on:
       - '.github/workflows/test-generator.yml'
 
 jobs:
-  # Create a pull request.
+
   test-generator:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     defaults:
       run:
         working-directory: library # sync with env.LIBRARY_CHECKOUT_PATH


### PR DESCRIPTION
This PR is overscoped, covering the following changes:

* Add a fallback test-generator job so this job can be required but still pass for changes unrelated to the generator
* Add permissions to workflows
* Fix concurrency of test-generator so it is scoped to run workflow-per-PR instead of one workflow across PRs.