### PR TITLE
fix(testing): generator workflow syntax error

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -45,6 +45,7 @@ jobs:
       LIBRARY_CHECKOUT_PATH: library # sync with defaults.run.working-directory
       DATA_SOURCE_CHECKOUT_PATH: protos-source-repo
 
+    steps:
     - name: Go Library > Checkout Repository
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
In a recent PR I broke the generator workflow. This fixes the syntax error. I filed #152 as a follow-up to detect & prevent further mistakes.