### PR TITLE
testing: Sort test cases per data package

### DIFF
--- a/generators/protoc-gen-go-googlecetypes/generator.go
+++ b/generators/protoc-gen-go-googlecetypes/generator.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -125,6 +126,7 @@ func generateTests(gen *protogen.Plugin, file *protogen.File) *protogen.Generate
 	for i := range dataTypeMap {
 		dataTypeSlice = append(dataTypeSlice, i)
 	}
+	sort.Strings(dataTypeSlice)
 	params.DataTypes = dataTypeSlice
 
 	// Create TestDataPath like "google/events/cloud/functions/v1"


### PR DESCRIPTION
Currently, the order of data types per validation test is non-deterministic. As a result, code generation PRs have a high degree of flux. This change sorts the data types into alphabetical order to minimize diff noise.