### PR TITLE
fix: support event type pre-release versions

### DIFF
--- a/generators/protoc-gen-go-googlecetypes/generator.go
+++ b/generators/protoc-gen-go-googlecetypes/generator.go
@@ -130,7 +130,7 @@ func generateTests(gen *protogen.Plugin, file *protogen.File) *protogen.Generate
 	params.DataTypes = dataTypeSlice
 
 	// Create TestDataPath like "google/events/cloud/functions/v1"
-	re := regexp.MustCompile(`(v\d)$`)
+	re := regexp.MustCompile(`(v\d+(\w+\d+)?)$`)
 	version := re.FindString(string(file.GoPackageName))
 	product := strings.TrimSuffix(string(file.GoPackageName), version)
 	product = strings.TrimSuffix(product, "data")


### PR DESCRIPTION
Fixes #159 

From the generator output on my local machine:

```
- audit: cloud/audit/v1/data.proto => cloud/auditdata
- dataflow: cloud/dataflow/v1beta3/data.proto => cloud/dataflowdatav1beta3
- functions: cloud/functions/v2/data.proto => cloud/functionsdatav2
```

New file added for DataFlow event type:

```
cloud/dataflowdatav1beta3/
```

