### PR TITLE
fix(renovate): schedule syntax correction for monthly runs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "config:base"
   ],
-  "schedule": ["every month on the first day of the month"],
+  "schedule": ["on the first day of the month"],
   "constraints": {
     "go": "1.21"
   }


### PR DESCRIPTION
Renovate objected to the current syntax in practice by opening #270. Here's a retry based on the syntax library examples at https://breejs.github.io/later/parsers.html#text. (This is referenced from the [renovate schedule config documentation](https://docs.renovatebot.com/configuration-options/#schedule))