### PR TITLE
docs: Update example to discard unknown fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ var cloudEventPayload = []byte(`
 
 func Example() {
 	data := storagedata.StorageObjectData{}
-	if err := protojson.Unmarshal(cloudEventPayload, &data); err != nil {
+
+	// If you omit `DiscardUnknown`, protojson.Unmarshal returns an error
+	// when encountering a new or unknown field.
+	options := protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}
+	if err := options.Unmarshal(cloudEventPayload, &data); err != nil {
 		log.Fatal("protojson.Unmarshal: ", err)
 	}
 

--- a/examples/example_storage_test.go
+++ b/examples/example_storage_test.go
@@ -34,7 +34,13 @@ var cloudEventPayload = []byte(`
 
 func Example() {
 	data := storagedata.StorageObjectData{}
-	if err := protojson.Unmarshal(cloudEventPayload, &data); err != nil {
+
+	// If you omit `DiscardUnknown`, protojson.Unmarshal returns an error
+	// when encountering a new or unknown field.
+	options := protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}
+	if err := options.Unmarshal(cloudEventPayload, &data); err != nil {
 		log.Fatal("protojson.Unmarshal: ", err)
 	}
 


### PR DESCRIPTION
Omit unknown fields in library examples.

Parallels https://github.com/GoogleCloudPlatform/golang-samples/pull/4758.