### PR TITLE
ci: Run test on library dependency updates

### DIFF
--- a/.github/workflows/test-generator-fallback.yml
+++ b/.github/workflows/test-generator-fallback.yml
@@ -27,6 +27,7 @@ on:
       - 'generators/**'
       - 'internal/**'
       - 'tools/**'
+      - 'go.*'
 
 jobs:
   test-generator:

--- a/.github/workflows/test-generator.yml
+++ b/.github/workflows/test-generator.yml
@@ -30,6 +30,7 @@ on:
       - 'generators/**'
       - 'internal/**'
       - 'tools/**'
+      - 'go.*'
 
 jobs:
 


### PR DESCRIPTION
Currently when go.mod or go.sum is updated, we do not run tests.

This change folds go.mod and go.sum into the testing process, so that changes to library dependencies lead to running the tests. Most of the test is generating the library, and these dependencies do not impact that. However, the final step of testing library generation is running the tests, and at that point verifying this dependency behavior is important.

In the future, we may split off a dedicated "test the library as-is with updated dependencies" workflow, but for now this is the lowest lift.