### PR TITLE
chore: replace old partner teams with new ones (Wave 2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/torus-dpe
+*     @googleapis/acep-team

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -23,5 +23,5 @@ branchProtectionRules:
   requiresCodeOwnerReviews: true
   requiresStrictStatusChecks: true
 permissionRules:
-  - team: torus-dpe
+  - team: acep-team
     permission: push

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -23,7 +23,5 @@ branchProtectionRules:
   requiresCodeOwnerReviews: true
   requiresStrictStatusChecks: true
 permissionRules:
-  - team: cloudevents-admins
-    permission: push
   - team: torus-dpe
-    permission: admin
+    permission: push


### PR DESCRIPTION
Replacing old partner teams with new ones as part of Wave 2 migration. b/478003109

As part of this change, we are also removing admin permissions from the repository settings in .github/sync-repo-settings.yaml. Teams that previously had admin access have been removed or updated to have push access.